### PR TITLE
Fix memory leak on trying to parse a file that doesn't exist

### DIFF
--- a/src/lib/fy-parse.c
+++ b/src/lib/fy-parse.c
@@ -150,6 +150,7 @@ int fy_parse_get_next_input(struct fy_parser *fyp)
 	return 1;
 
 err_out:
+	fy_input_unref(fyi);
 	return -1;
 }
 


### PR DESCRIPTION
As far as I can tell, `fy_input`s are normally freed via `fy_input_unref`, either through immediate failure in `fy_parse_input_append` (which doesn't happen, as the presence of the file is checked for later when it's actually used), or in `fy_parse_cleanup` where `fy_input_unref` is called on the `queued_inputs` and `parsed_inputs` lists as well as on `current_input`.

When failing to open the file, it is recorded in none of these places as failure happens between the `fy_parse_get_next_input` popping from `queued_inputs` and the setting of `current_input` to the popped item.

If I'm understanding this correctly, a possible fix could be adding a `fy_input_unref(fyi);` to the `err_out` label at `fy-parse.c:153`. This causes the test case below to behave as expected, while preserving the checks run with `make check`. However, this is the first time I've looked into the codebase, so I admit I'm not at all sure. :)

If `parsed_inputs` is only used for cleanup, perhaps it would be more appropriate for me to add the failed popped input to this list for deferred cleanup instead, perhaps renaming `parsed_inputs` at the same time, for clarity? 

Test:
```c
#include <libfyaml.h>

#include <assert.h>
#include <stdio.h>
#include <stdlib.h>

int main(void)
{
  int ret = EXIT_SUCCESS;
  const char location[] = "does-not-exist.yaml";
  struct fy_parse_cfg cfg = {
    .search_path = "",
    .flags =
      0 |
      FYPCF_DEBUG_LEVEL(3) |
      FYPCF_DEBUG_DIAG_DEFAULT | FYPCF_DEBUG_DEFAULT |
      FYPCF_RESOLVE_DOCUMENT | FYPCF_COLOR_FORCE
  };
  struct fy_parser *fyp = fy_parser_create(&cfg);
  int err = fy_parser_set_input_file(fyp, location);
  if (err) {
    fprintf(stderr, "We failed to set the input file!\n");
    ret = EXIT_FAILURE;
  }
  struct fy_document *doc = fy_parse_load_document(fyp);
  if (doc) {
    fprintf(stderr, "We managed to parse a configuration file we didn't expect to exist!\n");
    ret = EXIT_FAILURE;
  }
  if (doc) {
    fy_document_destroy(doc);
  }
  fy_parser_destroy(fyp);
  return ret;
}
```
Run:
```bash
gcc -gdwarf-4 -Wall -Wextra -pedantic -fsanitize=undefined -fsanitize=address $(pkg-config libfyaml --cflags --libs) test.c -o test
./test
```
Expected output:
```
[ERR]: failed to open does-not-exist.yaml
```

Actual output:
```
[ERR]: failed to open does-not-exist.yaml

=================================================================
==4418==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 144 byte(s) in 1 object(s) allocated from:
    #0 0x7fbb8613f330 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.5+0xe9330)
    #1 0x7fbb86005c7b in fy_input_alloc lib/fy-parse.c:686
    #2 0x7fbb86005e49 in fy_parse_input_alloc lib/fy-parse.c:763
    #3 0x7fbb86007772 in fy_parse_input_append lib/fy-parse.c:1228
    #4 0x7fbb8602130a in fy_parser_set_input_file lib/fy-parse.c:5665
    #5 0x56465c638462 in main test/test.c:21
    #6 0x7fbb8531609a in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: 144 byte(s) leaked in 1 allocation(s).
```