### PR TITLE
Update README.md - missing parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ YAML, or an invoice file given on the command line:
 
 ```c
 	if (argc == 1)
-		fyd = fy_document_build_from_string(NULL, yaml);
+		fyd = fy_document_build_from_string(NULL, yaml, -1);
 	else
 		fyd = fy_document_build_from_file(NULL, argv[1]);
 	if (!fyd) {
@@ -255,13 +255,13 @@ address.
 ```c
 	rc =
 		/* set increased invoice number (modify existing node) */
-		fy_document_insert_at(fyd, "/invoice",
+		fy_document_insert_at(fyd, "/invoice", -1,
 			fy_node_buildf(fyd, "%u", invoice_nr + 1)) ||
 		/* add spouse (create new mapping pair) */
-		fy_document_insert_at(fyd, "/bill-to",
+		fy_document_insert_at(fyd, "/bill-to", -1,
 			fy_node_buildf(fyd, "spouse: %s", "Doris")) ||
 		/* add a second address */
-		fy_document_insert_at(fyd, "/bill-to",
+		fy_document_insert_at(fyd, "/bill-to", -1,
 			fy_node_buildf(fyd, "delivery-address:\n"
 				            "  lines: |\n"
 					    "    1226 Windward Ave.\n"));


### PR DESCRIPTION
In the example in the README.md, the calls to **fy_document_build_from_string**, and **fy_document_insert_at** were missing the **len** and the **pathlen** parameters.
