### PR TITLE
added fy_node_set_style() method.

### DIFF
--- a/include/libfyaml.h
+++ b/include/libfyaml.h
@@ -2094,6 +2094,22 @@ fy_node_get_style(struct fy_node *fyn)
 	FY_EXPORT;
 
 /**
+ * fy_node_set_style() - Set the node style
+ *
+ * Set the node rendering style.
+ * If the node is NULL then an error code is returned.
+ *
+ * @fyn: The node
+ * @style: The node rendering style
+ *
+ * Returns:
+ * 0 on success, -1 on error.
+ */
+int
+fy_node_set_style(struct fy_node *fyn, enum fy_node_style style)
+	FY_EXPORT;
+
+/**
  * fy_node_is_scalar() - Check whether the node is a scalar
  *
  * Convenience method for checking whether a node is a scalar.

--- a/src/lib/fy-doc.c
+++ b/src/lib/fy-doc.c
@@ -3217,6 +3217,15 @@ enum fy_node_style fy_node_get_style(struct fy_node *fyn)
 	return fyn ? fyn->style : FYNS_PLAIN;
 }
 
+int fy_node_set_style(struct fy_node *fyn, enum fy_node_style style)
+{
+  if (fyn) {
+		fyn->style = style;
+		return 0;
+	}
+	return -1;
+}
+
 bool fy_node_is_attached(struct fy_node *fyn)
 {
 	return fyn ? fyn->attached : false;
@@ -6253,7 +6262,7 @@ int fy_node_hash_uint(struct fy_node *fyn, unsigned int *hashp)
 
 	XXH32_reset(&state, 2654435761U);
 
-	rc = fy_node_hash_internal(fyn, update_xx32, &state); 
+	rc = fy_node_hash_internal(fyn, update_xx32, &state);
 	if (rc)
 		return rc;
 


### PR DESCRIPTION
added the missing `fy_node_set_style()` method.  This allows user to control how each node is formatted by the emitter (flow v.s. block style, whether to quote the value, etc.)