### PR TITLE
Added missing `unistd.h` include in `libfyaml.h`

### DIFF
--- a/include/libfyaml.h
+++ b/include/libfyaml.h
@@ -38,6 +38,7 @@ extern "C" {
 #include <stdio.h>
 #include <string.h>
 #include <alloca.h>
+#include <unistd.h>
 
 /* opaque types for the user */
 struct fy_token;


### PR DESCRIPTION
Added the missing include directive for `unistd.h` in `libfyaml.h`.

`ssize_t` was used in `libfyaml.h` even though `unistd.h` was not included, and `ssize_t` is defined in `unistd.h`.

I've had the issue that I included `libfyaml.h` before including `unistd.h`, which lead to compiler errors.