### PR TITLE
Fix CMake scripts & add comments getter API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,39 +14,47 @@ include(GNUInstallDirs)
 set(LIBHDRS
   src/valgrind/fy-valgrind.h
   src/xxhash/xxhash.h
-  src/lib/fy-atom.h
-  src/lib/fy-token.h
   src/lib/fy-accel.h
-  src/lib/fy-utils.h
-  src/lib/fy-dump.h
+  src/lib/fy-atom.h
+  src/lib/fy-composer.h
+  src/lib/fy-ctype.h
+  src/lib/fy-diag.h
   src/lib/fy-doc.h
-  src/lib/fy-input.h
-  src/lib/fy-types.h
-  src/lib/fy-typelist.h
   src/lib/fy-docstate.h
-  src/lib/fy-parse.h
+  src/lib/fy-dump.h
+  src/lib/fy-emit-accum.h
   src/lib/fy-emit.h
   src/lib/fy-event.h
+  src/lib/fy-input.h
   src/lib/fy-list.h
+  src/lib/fy-parse.h
+  src/lib/fy-path.h
+  src/lib/fy-token.h
+  src/lib/fy-typelist.h
+  src/lib/fy-types.h
   src/lib/fy-utf8.h
-  src/lib/fy-diag.h
-  src/lib/fy-ctype.h
+  src/lib/fy-utils.h
+  src/lib/fy-walk.h
 )
 set(LIBSRCS
-  src/lib/fy-input.c
-  src/lib/fy-utils.c
-  src/lib/fy-utf8.c
-  src/lib/fy-ctype.c
-  src/lib/fy-emit.c
-  src/lib/fy-token.c
-  src/lib/fy-docstate.c
-  src/lib/fy-diag.c
-  src/lib/fy-dump.c
-  src/lib/fy-parse.c
-  src/lib/fy-doc.c
-  src/lib/fy-types.c
-  src/lib/fy-atom.c
   src/lib/fy-accel.c
+  src/lib/fy-atom.c
+  src/lib/fy-composer.c
+  src/lib/fy-ctype.c
+  src/lib/fy-diag.c
+  src/lib/fy-doc.c
+  src/lib/fy-docstate.c
+  src/lib/fy-dump.c
+  src/lib/fy-emit.c
+  src/lib/fy-event.c
+  src/lib/fy-input.c
+  src/lib/fy-parse.c
+  src/lib/fy-path.c
+  src/lib/fy-token.c
+  src/lib/fy-types.c
+  src/lib/fy-utf8.c
+  src/lib/fy-utils.c
+  src/lib/fy-walk.c
   src/xxhash/xxhash.c
 )
 set(LIBHDRSPUB
@@ -116,7 +124,7 @@ install(EXPORT ${PROJECT_NAME}-targets
 )
 export(
 	TARGETS ${PROJECT_NAME}
-	FILE "${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}-targets.cmake"
+	FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}-targets.cmake"
 	NAMESPACE ${PROJECT_NAME}::
 )
 
@@ -124,19 +132,19 @@ export(
 include(CMakePackageConfigHelpers)
 configure_package_config_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake.in
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}-config.cmake
     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )
 
 write_basic_package_version_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}-config-version.cmake
-    VERSION ${YART_VERSION}
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}-config-version.cmake
+    VERSION ${PROJECT_VERSION}
     COMPATIBILITY AnyNewerVersion
 )
 
 install(
     FILES
-        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake
-        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}-config-version.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}-config.cmake
+        ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}-config-version.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,9 @@ if (POLICY CMP0048)
     cmake_policy(SET CMP0048 NEW) # Allow project(xxx VERSION a.b.c)
 endif()
 
-
-project(fyaml LANGUAGES C VERSION 0.5.8)
+# version number below should be the currently under development version,
+# so when doing a tag/release it is captured with the proper numbering.
+project(fyaml LANGUAGES C VERSION 0.7.2)
 
 cmake_minimum_required(VERSION 3.0)
 

--- a/include/libfyaml.h
+++ b/include/libfyaml.h
@@ -916,6 +916,27 @@ const char *
 fy_token_get_text0(struct fy_token *fyt)
 	FY_EXPORT;
 
+enum fy_comment_placement {
+	fycp_top,
+	fycp_right,
+	fycp_bottom,
+	fycp_max,
+};
+
+/**
+ * fy_token_get_comment() - Get zero terminated comment of a token
+ *
+ * @fyt: The token out of which the comment text will be returned.
+ *
+ * Returns:
+ * A pointer to a zero terminated text representation of the token comment.
+ * NULL in case of an error or if the token has no comment.
+ */
+const char *
+fy_token_get_comment(struct fy_token *fyt, char *buf, size_t maxsz, 
+                     enum fy_comment_placement which)
+	FY_EXPORT;
+
 /**
  * fy_token_get_text_length() - Get length of the text of a token
  *

--- a/src/lib/fy-token.c
+++ b/src/lib/fy-token.c
@@ -1038,6 +1038,22 @@ const char *fy_token_get_text0(struct fy_token *fyt)
 	return fyt->text0;
 }
 
+const char *fy_token_get_comment(struct fy_token *fyt, char *buf, size_t maxsz,
+	enum fy_comment_placement which)
+{
+	if (!buf || maxsz == 0)
+		return NULL;
+
+	/* return empty? */
+	struct fy_atom *handle;
+	handle = fy_token_comment_handle(fyt, which, false);
+	if (!handle || !fy_atom_is_set(handle))
+		return NULL;
+
+	fy_atom_format_text(handle, buf, maxsz);
+	return buf;
+}
+
 size_t fy_token_get_text_length(struct fy_token *fyt)
 {
 	return fy_token_format_text_length(fyt);

--- a/src/lib/fy-token.h
+++ b/src/lib/fy-token.h
@@ -77,13 +77,6 @@ static inline bool fy_token_type_is_mapping_marker(enum fy_token_type type)
 #define FYACF_VALID_ANCHOR	0x040000	/* contains valid anchor (without & prefix) */
 #define FYACF_JSON_ESCAPE	0x080000	/* contains a character that JSON escapes */
 
-enum fy_comment_placement {
-	fycp_top,
-	fycp_right,
-	fycp_bottom,
-	fycp_max,
-};
-
 FY_TYPE_FWD_DECL_LIST(token);
 struct fy_token {
 	struct list_head node;


### PR DESCRIPTION
Description: 
- CMake scripts should NOT write into the source directory, but in the build dir (out-of-tree builds).
- I added a comments getter API, so users can retrieve comments associated to each token. 

The comments API has been thoroughly [tested](https://github.com/MRPT/mrpt/blob/develop/libs/containers/src/yaml_unittest.cpp) in a derived project where a C++ wrapper to this great C library is defined. Furthermore, this wrapper is used as a building block of another project ([repo](https://github.com/MOLAorg/mola-yaml), [docs](https://docs.mola-slam.org/latest/module-mola-yaml.html)) with its own unit tests. All pass with the code in this PR. 

If merged, it would be great to have another release (when time permits! @pantoniou ) since I intend to then package this library into Debian, so it could be easily installed into any Debian/Ubuntu future distro ;-)