### PR TITLE
Build on cygwin

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,7 +36,7 @@ libfyaml_la_CPPFLAGS = $(AM_CPPFLAGS) \
 		       -I$(top_srcdir)/src/xxhash \
 		       -I$(top_srcdir)/src/util
 libfyaml_la_CFLAGS = $(AM_CFLAGS)
-libfyaml_la_LDFLAGS = $(AM_LDFLAGS) $(AM_LIBLDFLAGS) \
+libfyaml_la_LDFLAGS = -no-undefined $(AM_LDFLAGS) $(AM_LIBLDFLAGS) \
 		      -version $(LIBTOOL_VERSION)
 
 bin_PROGRAMS =


### PR DESCRIPTION
Build on cygwin

```
$ uname -mrs
CYGWIN_NT-10.0-19045 3.4.6-1.x86_64 x86_64
$ cd libfyaml
$ autoreconf -fiv
$ ./configure --disable-static --enable-shared
$ make V=1
Making all in src
/bin/sh ../libtool --tag=CC --mode=link '/bin/sh' '/tmp/libfyaml/build-aux/shave' 'cc' 'gcc' '-Wall' '-Wsign-compare' '-Wno-stringop-overflow' '-fvisibility=hidden' '-O2' '-version' '1:3:1' -o 'libfyaml.la' '-rpath' '/usr/local/lib' 'lib/libfyaml_la-fy-parse.lo' 'lib/libfyaml_la-fy-types.lo' 'lib/libfyaml_la-fy-diag.lo' 'lib/libfyaml_la-fy-dump.lo' 'lib/libfyaml_la-fy-atom.lo' 'lib/libfyaml_la-fy-token.lo' 'lib/libfyaml_la-fy-input.lo' 'lib/libfyaml_la-fy-docstate.lo' 'lib/libfyaml_la-fy-doc.lo' 'lib/libfyaml_la-fy-docbuilder.lo' 'lib/libfyaml_la-fy-emit.lo' 'lib/libfyaml_la-fy-event.lo' 'lib/libfyaml_la-fy-accel.lo' 'lib/libfyaml_la-fy-walk.lo' 'lib/libfyaml_la-fy-path.lo' 'lib/libfyaml_la-fy-composer.lo' 'xxhash/libfyaml_la-xxhash.lo' 'util/libfyaml_la-fy-ctype.lo' 'util/libfyaml_la-fy-utf8.lo' 'util/libfyaml_la-fy-utils.lo' 'util/libfyaml_la-fy-blob.lo' --shave-mode=link
libtool:   error: can't build x86_64-pc-cygwin shared library unless -no-undefined is specified
make[2]: *** [Makefile:719: libfyaml.la] Error 1
make[1]: *** [Makefile:574: all-recursive] Error 1
make: *** [Makefile:479: all] Error 2
```