### PR TITLE
Problem: byteswap.h is not available on all platforms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,9 @@ AC_TYPE_SIGNAL
 AC_TYPE_UID_T
 AC_CHECK_DECLS(environ)
 
+AC_CHECK_HEADERS([byteswap.h])
+AC_CHECK_FUNCS([__builtin_bswap16 __builtin_bswap32 __builtin_bswap64])
+
 dnl for old autoconf version AX_APPEND_COMPILE_FLAGS does not work
 m4_version_prereq(2.64,
 	 [AX_APPEND_COMPILE_FLAGS([-Wall -Wsign-compare -Wno-stringop-overflow -fvisibility=hidden],

--- a/src/util/fy-blob.h
+++ b/src/util/fy-blob.h
@@ -15,7 +15,32 @@
 #include <string.h>
 #include <stdint.h>
 #include <assert.h>
+#ifdef HAVE_BYTESWAP_H
 #include <byteswap.h>
+#else
+#ifdef HAVE___BUILTIN_BSWAP16
+#define bswap_16(value) __builtin_bswap16(value)
+#else
+#define bswap_16(value) ((((value)&0xff) << 8) | ((value) >> 8))
+#endif
+
+#ifdef HAVE___BUILTIN_BSWAP32
+#define bswap_32(value) __builtin_bswap32(value)
+#else
+#define bswap_32(value)                                                                            \
+  (((uint32_t)bswap_16((uint16_t)((value)&0xffff)) << 16) |                                        \
+   (uint32_t)bswap_16((uint16_t)((value) >> 16)))
+#endif
+
+#ifdef HAVE___BUILTIN_BSWAP64
+#define bswap_64(value) __builtin_bswap64(value)
+#else
+#define bswap_64(value)                                                                            \
+  (((uint64_t)bswap_32((uint32_t)((value)&0xffffffff)) << 32) |                                    \
+   (uint64_t)bswap_32((uint32_t)((value) >> 32)))
+#endif
+#endif
+
 #include <stdbool.h>
 #include <time.h>
 


### PR DESCRIPTION
Most notably, it's not available on macOS.

Solution: supply fallback implementations (builtins and naive)

# #82 includes this and #81 to make it easier to integrate