### PR TITLE
Problem: byteswap.h is not available on all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,13 @@ add_library(${PROJECT_NAME}
     ${LIBHDRSPUB}
 )
 
+include(CheckIncludeFile)
+check_include_file("byteswap.h" HAVE_BYTESWAP_H)
+include(CheckFunctionExists)
+check_function_exists(__builtin_bswap16 HAVE___BUILTIN_BSWAP16)
+check_function_exists(__builtin_bswap32 HAVE___BUILTIN_BSWAP32)
+check_function_exists(__builtin_bswap64 HAVE___BUILTIN_BSWAP64)
+
 add_library(${PROJECT_NAME}::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
 
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER "Libraries")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,38 +13,38 @@ cmake_minimum_required(VERSION 3.0)
 include(GNUInstallDirs)
 
 set(LIBHDRS
-  src/valgrind/fy-valgrind.h
-  src/xxhash/xxhash.h
   src/lib/fy-accel.h
   src/lib/fy-atom.h
   src/lib/fy-composer.h
-  src/lib/fy-ctype.h
   src/lib/fy-diag.h
   src/lib/fy-doc.h
-  src/lib/fy-docbuilder.c
+  src/lib/fy-docbuilder.h
   src/lib/fy-docstate.h
   src/lib/fy-dump.h
-  src/lib/fy-emit-accum.h
-  src/lib/fy-emit.h
-  src/lib/fy-event.h
+  src/lib/fy-emit.h src/lib/fy-emit-accum.h
   src/lib/fy-input.h
-  src/lib/fy-list.h
   src/lib/fy-parse.h
   src/lib/fy-path.h
   src/lib/fy-token.h
-  src/lib/fy-typelist.h
   src/lib/fy-types.h
-  src/lib/fy-utf8.h
-  src/lib/fy-utils.h
   src/lib/fy-walk.h
+  src/util/fy-blob.h
+  src/util/fy-ctype.h
+  src/util/fy-endian.h
+  src/util/fy-id.h
+  src/util/fy-list.h
+  src/util/fy-typelist.h
+  src/util/fy-utf8.h
+  src/util/fy-utils.h
+  src/xxhash/xxhash.h
 )
 set(LIBSRCS
   src/lib/fy-accel.c
   src/lib/fy-atom.c
   src/lib/fy-composer.c
-  src/lib/fy-ctype.c
   src/lib/fy-diag.c
   src/lib/fy-doc.c
+  src/lib/fy-docbuilder.c
   src/lib/fy-docstate.c
   src/lib/fy-dump.c
   src/lib/fy-emit.c
@@ -54,9 +54,11 @@ set(LIBSRCS
   src/lib/fy-path.c
   src/lib/fy-token.c
   src/lib/fy-types.c
-  src/lib/fy-utf8.c
-  src/lib/fy-utils.c
   src/lib/fy-walk.c
+  src/util/fy-blob.c
+  src/util/fy-ctype.c
+  src/util/fy-utf8.c
+  src/util/fy-utils.c
   src/xxhash/xxhash.c
 )
 set(LIBHDRSPUB
@@ -79,7 +81,7 @@ target_include_directories(${PROJECT_NAME}
         $<INSTALL_INTERFACE:include>
     PRIVATE
         ${${PROJECT_NAME}_SOURCE_DIR}/src/lib
-        ${${PROJECT_NAME}_SOURCE_DIR}/src/lib/internal
+        ${${PROJECT_NAME}_SOURCE_DIR}/src/util
         ${${PROJECT_NAME}_SOURCE_DIR}/src/xxhash
 )
 

--- a/configure.ac
+++ b/configure.ac
@@ -117,6 +117,9 @@ AC_TYPE_SIGNAL
 AC_TYPE_UID_T
 AC_CHECK_DECLS(environ)
 
+AC_CHECK_HEADERS([byteswap.h])
+AC_CHECK_FUNCS([__builtin_bswap16 __builtin_bswap32 __builtin_bswap64])
+
 dnl for old autoconf version AX_APPEND_COMPILE_FLAGS does not work
 m4_version_prereq(2.64,
 	 [AX_APPEND_COMPILE_FLAGS([-Wall -Wsign-compare -Wno-stringop-overflow -fvisibility=hidden],

--- a/src/util/fy-blob.h
+++ b/src/util/fy-blob.h
@@ -15,7 +15,32 @@
 #include <string.h>
 #include <stdint.h>
 #include <assert.h>
+#ifdef HAVE_BYTESWAP_H
 #include <byteswap.h>
+#else
+#ifdef HAVE___BUILTIN_BSWAP16
+#define bswap_16(value) __builtin_bswap16(value)
+#else
+#define bswap_16(value) ((((value)&0xff) << 8) | ((value) >> 8))
+#endif
+
+#ifdef HAVE___BUILTIN_BSWAP32
+#define bswap_32(value) __builtin_bswap32(value)
+#else
+#define bswap_32(value)                                                                            \
+  (((uint32_t)bswap_16((uint16_t)((value)&0xffff)) << 16) |                                        \
+   (uint32_t)bswap_16((uint16_t)((value) >> 16)))
+#endif
+
+#ifdef HAVE___BUILTIN_BSWAP64
+#define bswap_64(value) __builtin_bswap64(value)
+#else
+#define bswap_64(value)                                                                            \
+  (((uint64_t)bswap_32((uint32_t)((value)&0xffffffff)) << 32) |                                    \
+   (uint64_t)bswap_32((uint32_t)((value) >> 32)))
+#endif
+#endif
+
 #include <stdbool.h>
 #include <time.h>
 


### PR DESCRIPTION
This PR supersedes both #80 and #81 as it combines both of them.
---

Most notably, it's not available on macOS.

Solution: supply fallback implementations (builtins and naive)