### PR TITLE
Problem: can't get to node's token

### DIFF
--- a/include/libfyaml.h
+++ b/include/libfyaml.h
@@ -3020,6 +3020,36 @@ fy_node_get_style(struct fy_node *fyn)
 	FY_EXPORT;
 
 /**
+ * fy_node_get_start_token() - Get the node start token
+ *
+ * Retrieve the node start token.
+ *
+ * For scalars, this is the same as the end token.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * The node start token
+ */
+struct fy_token * fy_node_get_start_token(struct fy_node *fyn)
+        FY_EXPORT;
+
+/**
+ * fy_node_get_end_token() - Get the node end token
+ *
+ * Retrieve the node end token.
+ *
+ * For scalars, this is the same as the start token.
+ *
+ * @fyn: The node
+ *
+ * Returns:
+ * The node end token
+ */
+ struct fy_token * fy_node_get_end_token(struct fy_node *fyn)
+        FY_EXPORT;
+
+/**
  * fy_node_is_scalar() - Check whether the node is a scalar
  *
  * Convenience method for checking whether a node is a scalar.

--- a/src/lib/fy-doc.c
+++ b/src/lib/fy-doc.c
@@ -3380,6 +3380,35 @@ enum fy_node_style fy_node_get_style(struct fy_node *fyn)
 	return fyn ? fyn->style : FYNS_PLAIN;
 }
 
+struct fy_token * fy_node_get_start_token(struct fy_node *fyn) {
+        if (!fyn) {
+                return NULL;
+        }
+        switch (fyn->type) {
+        case FYNT_MAPPING:
+                return fyn->mapping_start;
+        case FYNT_SEQUENCE:
+                return fyn->sequence_start;
+        case FYNT_SCALAR:
+                return fyn->scalar;
+        }
+}
+
+
+struct fy_token * fy_node_get_end_token(struct fy_node *fyn) {
+        if (!fyn) {
+                return NULL;
+        }
+        switch (fyn->type) {
+        case FYNT_MAPPING:
+                return fyn->mapping_end;
+        case FYNT_SEQUENCE:
+                return fyn->sequence_end;
+        case FYNT_SCALAR:
+                return fyn->scalar;
+        }
+}
+
 bool fy_node_is_null(struct fy_node *fyn)
 {
 	if (!fyn)

--- a/test/libfyaml-test-core.c
+++ b/test/libfyaml-test-core.c
@@ -1922,6 +1922,79 @@ START_TEST(scanf_check)
 }
 END_TEST
 
+START_TEST(token_test) {
+        struct fy_document *fyd;
+        struct fy_node *fyn_sequence, *fyn_mapping, *fyn_scalar;
+        struct fy_token *fyn_sequence_start, *fyn_sequence_end,
+            *fyn_mapping_start, *fyn_mapping_end, *fyn_scalar_token;
+        struct fy_parse_cfg cfg = {
+            .flags =  FYPCF_PARSE_COMMENTS
+        };
+        int ret, ival;
+        char sval[256];
+
+        /* build document */
+
+        fyd = fy_document_build_from_string(&cfg, "- name: key\n"
+                                                     "  value: value\n", FY_NT);
+
+
+        /* Root (sequence) */
+        fyn_sequence = fy_document_root(fyd);
+        ck_assert_ptr_ne(fyn_sequence, NULL);
+
+        fyn_sequence_start = fy_node_get_start_token(fyn_sequence);
+        ck_assert_ptr_ne(fyn_sequence_start, NULL);
+
+        ck_assert_ptr_ne(fy_token_start_mark(fyn_sequence_start), NULL);
+
+        ck_assert_int_eq(fy_token_start_mark(fyn_sequence_start)->line, 0);
+        ck_assert_int_eq(fy_token_start_mark(fyn_sequence_start)->column, 0);
+
+        fyn_sequence_end = fy_node_get_end_token(fyn_sequence);
+        ck_assert_ptr_ne(fyn_sequence_end, NULL);
+
+        ck_assert_int_eq(fy_token_end_mark(fyn_sequence_end)->line, 2);
+        ck_assert_int_eq(fy_token_end_mark(fyn_sequence_end)->column, 0);
+
+        /* Mapping (sequence item) */
+        fyn_mapping = fy_node_sequence_get_by_index(fyn_sequence, 0);
+        ck_assert_ptr_ne(fyn_mapping, NULL);
+
+        fyn_mapping_start = fy_node_get_start_token(fyn_mapping);
+        ck_assert_ptr_ne(fyn_mapping_start, NULL);
+
+        ck_assert_ptr_ne(fy_token_start_mark(fyn_mapping), NULL);
+
+        ck_assert_int_eq(fy_token_start_mark(fyn_mapping_start)->line, 0);
+        ck_assert_int_eq(fy_token_start_mark(fyn_mapping_start)->column, 2);
+
+        fyn_mapping_end = fy_node_get_end_token(fyn_mapping);
+        ck_assert_ptr_ne(fyn_mapping_end, NULL);
+
+        ck_assert_ptr_ne(fy_token_start_mark(fyn_mapping), NULL);
+
+        ck_assert_int_eq(fy_token_start_mark(fyn_mapping_end)->line, 2);
+        ck_assert_int_eq(fy_token_start_mark(fyn_mapping_end)->column, 0);
+
+        /* Scalar (key) */
+        fyn_scalar = fy_node_pair_key(fy_node_mapping_get_by_index(fyn_mapping, 0));
+        ck_assert_ptr_ne(fyn_scalar, NULL);
+
+        fyn_scalar_token = fy_node_get_start_token(fyn_scalar);
+        ck_assert_ptr_ne(fyn_scalar_token, NULL);
+        ck_assert_ptr_eq(fyn_scalar_token, fy_node_get_end_token(fyn_scalar));
+
+        ck_assert_ptr_ne(fy_token_start_mark(fyn_scalar_token), NULL);
+        ck_assert_int_eq(fy_token_start_mark(fyn_scalar_token)->line, 0);
+        ck_assert_int_eq(fy_token_start_mark(fyn_scalar_token)->column, 2);
+
+        ck_assert_ptr_ne(fy_token_end_mark(fyn_scalar_token), NULL);
+        ck_assert_int_eq(fy_token_end_mark(fyn_scalar_token)->line, 0);
+        ck_assert_int_eq(fy_token_end_mark(fyn_scalar_token)->column, 6);
+}
+END_TEST
+
 TCase *libfyaml_case_core(void)
 {
 	TCase *tc;
@@ -1990,6 +2063,8 @@ TCase *libfyaml_case_core(void)
 	tcase_add_test(tc, alloca_check);
 
 	tcase_add_test(tc, scanf_check);
+
+        tcase_add_test(tc, token_test);
 
 	return tc;
 }


### PR DESCRIPTION
This is sometimes very useful, particularly for finding node's start/end marks and similar information.

Solution: expose it through exported functions