### PR TITLE
Problem: implementing custom comparison methods

### DIFF
--- a/include/libfyaml.h
+++ b/include/libfyaml.h
@@ -2592,6 +2592,16 @@ typedef int (*fy_node_mapping_sort_fn)(const struct fy_node_pair *fynp_a,
 				       void *arg);
 
 /**
+ * fy_node_mapping_sort_cmp_default() - Mapping sort of two scalars, default implementation
+ *
+ * Implements fy_node_mapping_sort_fn
+ *
+ */
+int fy_node_mapping_sort_cmp_default(const struct fy_node_pair *fynp_a,
+					    const struct fy_node_pair *fynp_b,
+					    void *arg);
+
+/**
  * typedef fy_node_scalar_compare_fn - Node compare method function for scalars
  *
  * @fyn_a: The first scalar node used in the comparison
@@ -2606,6 +2616,16 @@ typedef int (*fy_node_mapping_sort_fn)(const struct fy_node_pair *fynp_a,
 typedef int (*fy_node_scalar_compare_fn)(struct fy_node *fyn_a,
 					 struct fy_node *fyn_b,
 					 void *arg);
+
+/**
+ * fy_node_scalar_cmp_default() - Compare two scalars, default implementation
+ *
+ * Implements fy_node_scalar_compare_fn
+ *
+ */
+int fy_node_scalar_cmp_default(struct fy_node *fyn_a,
+				      struct fy_node *fyn_b,
+				      void *arg);
 
 /**
  * fy_node_compare() - Compare two nodes for equality

--- a/src/lib/fy-doc.c
+++ b/src/lib/fy-doc.c
@@ -1158,14 +1158,6 @@ struct fy_node_cmp_arg {
 	void *arg;
 };
 
-static int fy_node_scalar_cmp_default(struct fy_node *fyn_a,
-				      struct fy_node *fyn_b,
-				      void *arg);
-
-static int fy_node_mapping_sort_cmp_default(const struct fy_node_pair *fynp_a,
-					    const struct fy_node_pair *fynp_b,
-					    void *arg);
-
 bool fy_node_compare_user(struct fy_node *fyn1, struct fy_node *fyn2,
 			 fy_node_mapping_sort_fn sort_fn, void *sort_fn_arg,
 			 fy_node_scalar_compare_fn cmp_fn, void *cmp_fn_arg)
@@ -5760,7 +5752,7 @@ static int fy_node_mapping_sort_cmp_no_qsort_r(const void *a, const void *b)
 
 #endif
 
-static int fy_node_scalar_cmp_default(struct fy_node *fyn_a,
+int fy_node_scalar_cmp_default(struct fy_node *fyn_a,
 				      struct fy_node *fyn_b,
 				      void *arg)
 {
@@ -5775,7 +5767,7 @@ static int fy_node_scalar_cmp_default(struct fy_node *fyn_a,
 }
 
 /* the default sort method */
-static int fy_node_mapping_sort_cmp_default(const struct fy_node_pair *fynp_a,
+int fy_node_mapping_sort_cmp_default(const struct fy_node_pair *fynp_a,
 					    const struct fy_node_pair *fynp_b,
 					    void *arg)
 {


### PR DESCRIPTION
While the comparison method to be created would benefit from being able to fall back onto the default implementation, it can't do so as these default methods are private to libfyaml and are not exposed.

Solution: make them available as a public interface