### PR TITLE
Statically-link `fy-tool`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -189,7 +189,7 @@ fy_tool_SOURCES = \
 fy_tool_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/src/valgrind
 fy_tool_LDADD = $(AM_LDADD) libfyaml.la
 fy_tool_CFLAGS = $(AM_CFLAGS)
-fy_tool_LDFLAGS = $(AM_LDFLAGS)
+fy_tool_LDFLAGS = $(AM_LDFLAGS) -static
 
 include_HEADERS = \
         $(top_srcdir)/include/libfyaml.h


### PR DESCRIPTION
## Issue
It'd be desirable to be able to build `fy-tool` as a standalone binary to consume in our build systems to format YAML files, vs the current state where other libs need to be installed in order for the tool to function

## Summary
Statically-link `fy-tool`