### PR TITLE
Fix emit event create apis

### DIFF
--- a/src/lib/fy-emit.c
+++ b/src/lib/fy-emit.c
@@ -1376,7 +1376,7 @@ out:
 		 * - plain in block mode that can't be plain in flow mode
 		 * - special handling for plains on start of line
 		 */
-		if ((flow && !(aflags & FYTTAF_CAN_BE_PLAIN_FLOW) && !is_null_scalar) ||
+		if ((flow && !(aflags & FYTTAF_CAN_BE_PLAIN_FLOW) && !(aflags & FYTTAF_CAN_BE_SIMPLE_KEY) && !is_null_scalar) ||
 		    ((aflags & FYTTAF_QUOTE_AT_0) && indent == 0))
 			style = FYNS_DOUBLE_QUOTED;
 	}

--- a/src/lib/fy-input.c
+++ b/src/lib/fy-input.c
@@ -128,18 +128,10 @@ static void fy_input_from_data_setup(struct fy_input *fyi,
 	handle->end_mark.input_pos = size;
 	handle->end_mark.line = 0;
 	handle->end_mark.column = fy_utf8_count(data, size);
-	/* if it's plain, all is good */
-	if (simple || (aflags & FYACF_FLOW_PLAIN)) {
-		handle->storage_hint = size;	/* maximum */
-		handle->storage_hint_valid = false;
-		handle->direct_output = !!(aflags & FYACF_JSON_ESCAPE);
-		handle->style = FYAS_PLAIN;
-	} else {
-		handle->storage_hint = 0;	/* just calculate */
-		handle->storage_hint_valid = false;
-		handle->direct_output = false;
-		handle->style = FYAS_DOUBLE_QUOTED_MANUAL;
-	}
+	handle->storage_hint = 0;	/* just calculate */
+	handle->storage_hint_valid = false;
+	handle->direct_output = false;
+	handle->style = FYAS_DOUBLE_QUOTED_MANUAL;
 	handle->empty = !!(aflags & FYACF_EMPTY);
 	handle->has_lb = !!(aflags & FYACF_LB);
 	handle->has_ws = !!(aflags & FYACF_WS);

--- a/src/lib/fy-token.c
+++ b/src/lib/fy-token.c
@@ -1515,6 +1515,12 @@ unsigned int fy_analyze_scalar_content(const char *data, size_t size,
 	if (break_run > 1)
 		flags |= FYACF_TRAILING_LB;
 
+	if ((flags & FYACF_STARTS_WITH_WS) ||
+		(flags & FYACF_STARTS_WITH_LB) ||
+		(flags & FYACF_ENDS_WITH_WS) ||
+		(flags & FYACF_ENDS_WITH_LB))
+		flags &= ~FYACF_FLOW_PLAIN;
+
 	return flags;
 }
 

--- a/src/lib/fy-token.c
+++ b/src/lib/fy-token.c
@@ -686,14 +686,13 @@ int fy_token_text_analyze(struct fy_token *fyt)
 	cn = fy_atom_iter_utf8_get(&iter);
 	if (cn < 0) {
 		/* empty? */
-		flags |= FYTTAF_EMPTY | FYTTAF_CAN_BE_DOUBLE_QUOTED | FYTTAF_CAN_BE_UNQUOTED_PATH_KEY;
+		flags |= FYTTAF_EMPTY | FYTTAF_CAN_BE_DOUBLE_QUOTED | FYTTAF_CAN_BE_UNQUOTED_PATH_KEY | FYTTAF_CAN_BE_SIMPLE_KEY;
 		goto out;
 	}
 
 	flags |= FYTTAF_CAN_BE_PLAIN |
 		 FYTTAF_CAN_BE_SINGLE_QUOTED |
 		 FYTTAF_CAN_BE_DOUBLE_QUOTED |
-		 FYTTAF_CAN_BE_LITERAL |
 		 FYTTAF_CAN_BE_LITERAL |
 		 FYTTAF_CAN_BE_FOLDED |
 		 FYTTAF_CAN_BE_PLAIN_FLOW |

--- a/src/util/fy-utils.c
+++ b/src/util/fy-utils.c
@@ -295,6 +295,9 @@ int fy_tag_handle_length(const char *data, size_t len)
 	s += w;
 
 	c = fy_utf8_get(s, e - s, &w);
+	if (c == -1)
+		return len;
+
 	if (fy_is_ws(c))
 		return s - data;
 	/* if first character is !, empty handle */
@@ -364,7 +367,7 @@ int fy_tag_scan(const char *data, size_t len, struct fy_tag_scan_info *info)
 		/* either !suffix or !handle!suffix */
 		/* we scan back to back, and split handle/suffix */
 		handle_length = fy_tag_handle_length(s, e - s);
-		if (handle_length <= 0)
+		if (handle_length < 0)
 			return -1;
 		s += handle_length;
 	}


### PR DESCRIPTION
As discovered in investigating #109, there are issues with using `fy_emit_event_create` (and similar apis) that cause tokens to be emitted incorrectly, specifically, whitespace-only scalars.

After implementing #110 to test the `fy_emit_event_create` code path fully, 15 failing tests revealed other issues.

**With the fixes below, the existing and newly added tests in #110 all PASS.**

The test-only PR was created as a precaution, considering the uncertainty of fixing all the issues initially observed. Now that the tests have passed, I can merge the two PRs if that is the preferred course of action.

Details of fixed issues:

### Whitespace-Only Strings

`fy_analyze_scalar_content` returned `FYACF_FLOW_PLAIN` in the flags for whitespace-only strings. This flag is now removed when the scalar starts or ends with whitespace or newlines.

Failing tests:
* `emitter-examples/dqscalar.yaml`
* `emitter-examples/scalar-space.yaml`
* `emitter-examples/scalar-space1.yaml`
* `emitter-examples/sqscalar.yaml`
* `emitter-examples/sqscalarspace.yaml`

### Zero-length Scalars as Mapping Keys

`fy_token_text_analyze` never added the `FYTTAF_CAN_BE_SIMPLE_KEY` flag to zero-length scalars. This was added and checked for when emitting `FYSS_PLAIN` scalars.

Failing tests:
* `emitter-examples/seq2.yaml`
* `emitter-examples/seq4.yaml`
* `emitter-examples/t5.yaml`
* `emitter-examples/u.yaml`
* `emitter-examples/u1.yaml`
* `emitter-examples/u2.yaml`

### Pain Scalars with Newlines

`fy_input_from_data_setup` had an explicit path for `simple` or `FYACF_FLOW_PLAIN` inputs that caused `FYSS_PLAIN` scalars, containing newlines, to be output with the newlines as spaces; this was removed.

Failing tests:
* `emitter-examples/plainlines.yaml`
* `emitter-examples/plainscalar.yaml`
* `emitter-examples/scalar-multiline.yaml`

### Tags with Zero-length Handles

Tags with a zero-length handle (e.g. `!`) were considered invalid. In `fy_tag_scan` this replaces the test for `handle_length <= 0`, with just less than zero.

> [!NOTE]
> This change is validated by the fact that further down in `fy_tag_scan` there is a check for `handle_length == 0’, meaning it is expets zero-length handles and handles them properly.

Failing tests:
* `emitter-examples/emoji.yaml`

