### PR TITLE
Fix emission of document start markers

### DIFF
--- a/src/lib/fy-docstate.h
+++ b/src/lib/fy-docstate.h
@@ -33,6 +33,7 @@ struct fy_document_state {
 	bool tags_explicit : 1;
 	bool start_implicit : 1;
 	bool end_implicit : 1;
+	bool started_explicit : 1;
 	bool json_mode : 1;
 	struct fy_mark start_mark;
 	struct fy_mark end_mark;

--- a/src/lib/fy-emit.c
+++ b/src/lib/fy-emit.c
@@ -1912,7 +1912,9 @@ int fy_emit_common_document_end(struct fy_emitter *emit, bool override_state, bo
 	fyds = emit->fyds;
 
 	implicit = fyds->end_implicit;
-	if (override_state)
+	if (fyds->started_explicit)
+		implicit = false;
+	else if (override_state)
 		implicit = implicit_override;
 
 	dem = ((dem_flags == FYECF_DOC_END_MARK_AUTO && !implicit) ||
@@ -2975,8 +2977,10 @@ static int fy_emit_streaming_node(struct fy_emitter *emit, struct fy_parser *fyp
 	case FYET_SCALAR:
 		/* if we're pretty and at column 0 (meaning it's a single scalar document) output --- */
 		if ((emit->s_flags & DDNF_ROOT) && fy_emit_is_pretty_mode(emit) && !emit->column &&
-				!fy_emit_is_flow_mode(emit) && !(emit->s_flags & DDNF_FLOW))
+				!fy_emit_is_flow_mode(emit) && !(emit->s_flags & DDNF_FLOW)) {
 			fy_emit_document_start_indicator(emit);
+			emit->fyds->started_explicit = true;
+		}
 		fy_emit_common_node_preamble(emit, fye->scalar.anchor, fye->scalar.tag, emit->s_flags, emit->s_indent);
 		style = fye->scalar.value ?
 				fy_node_style_from_scalar_style(fye->scalar.value->scalar.style) :

--- a/src/lib/fy-emit.c
+++ b/src/lib/fy-emit.c
@@ -663,8 +663,7 @@ void fy_emit_common_node_preamble(struct fy_emitter *emit,
 	}
 
 	/* content for root always starts on a new line */
-	if ((flags & DDNF_ROOT) && emit->column != 0 &&
-            !(emit->flags & FYEF_HAD_DOCUMENT_START)) {
+	if ((flags & DDNF_ROOT) && emit->column != 0) {
 		fy_emit_putc(emit, fyewt_linebreak, '\n');
 		emit->flags = FYEF_WHITESPACE | FYEF_INDENTATION;
 	}


### PR DESCRIPTION
This fixes two issues with emitting document start/end markers and root scalar values. The first is that document start markers and root scalars are output on the same line, and the second is pretty mode forces document start markers but doesn't emit the matching end marker. 

### Isolated Document Start Markers

Currently, when emitting a single scalar value as the root object of a document with document markers enabled, some scalars (e.g., plain string) are output on the same line as the document start marker.


For example, the following code:
```c
fy_emit_eventf(emit, FYET_STREAM_START);
fy_emit_eventf(emit, FYET_DOCUMENT_START, false, NULL, NULL);
fy_emit_event(emit, FYET_SCALAR, FYSS_PLAIN, "simple", FY_NT, NULL, NULL);
fy_emit_eventf(emitter, FYET_DOCUMENT_END, false);
```

Generates this YAML:
```yaml
--- simple
...

```

This looked incorrect, so I looked into whether it was valid YAML. The YAML spec, section 9.1.2, refers to them as "lines":

> The solution is the use of two special marker **lines** to control the processing of directives, one at the start of a document and one at the end.

However, it gives an example of a document marker with a comment afterward. Also, `libyaml` accepts YAML with the scalar on the same line as the document marker.

_**In any case, it still seems wrong to emit them on the same line when you consider the spec language and how visually unpleasing it is.**_

With this change, the document start markers are always emitted on their own line, like:
```yaml
---
simple
...

```


### Emit Root Scalar with Pretty Mode

When emitting a single root scalar value in pretty mode, a document start marker is emitted, even when implicit markers are requested.

This leads to imbalanced output (in pretty mode), like:
```yaml
--- simple

```

The PR tracks when an implicit document start marker is requested but emitted anyway, like in pretty mode, and forces the emission of a matching document end marker.

> [!NOTE]
> This currently only affects emitted YAML when pretty mode is enabled because, currently, that is the only time a document start marker may be forced. Although, the new flag could be used in other situations.
