### PR TITLE
switch skip and xfail

### DIFF
--- a/test/testsuite-json.test
+++ b/test/testsuite-json.test
@@ -22,10 +22,10 @@ done
 # output plan
 echo 1..$count
 
-declare -A skips=(
+declare -A xfails=(
 	[UGM3]="Later jq versions rewrite numbers like 12.00 -> 12 which breaks diff"
 )
-declare -A xfails=(
+declare -A skips=(
 	[C4HZ]="requires schema support which libfyaml does not support yet."
 )
 


### PR DESCRIPTION
C4HZ is not supported and should be skipped (as in 0.9), UGM3 fails due to a change in behavior of jq and, hence, failures should not be detrimental