### PR TITLE
Minor Documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,22 +46,22 @@ of its testsuite.
 libfyaml is primarily developed on Linux based debian distros but Apple MacOS X builds
 (using homebrew) are supported as well.
 
-On a based debian distro (i.e. ubuntu 19.04 disco) you should install the following
+On a Debian-based distro (i.e. Ubuntu 24.04 noble) you should install the following
 dependencies:
 
-* `sudo apt-get install gcc autoconf automake libtool git make libltdl-dev pkg-config`
+* `sudo apt install gcc autoconf automake libtool git make libltdl-dev pkg-config`
 
 To enable the libyaml comparison checker:
 
-* `sudo apt-get install libyaml-dev`
+* `sudo apt install libyaml-dev`
 
 For the API testsuite libcheck is required:
 
-* `sudo apt-get install check`
+* `sudo apt install check`
 
 And finally in order to build the sphinx based documentation:
 
-* `sudo apt-get install python3 python3-pip python3-setuptools`
+* `sudo apt install python3 python3-pip python3-setuptools`
 * `pip3 install wheel sphinx git+http://github.com/return42/linuxdoc.git sphinx\_rtd\_theme sphinx-markdown-builder`
 
 Note that some older distros (like xenial) do not have a sufficiently recent


### PR DESCRIPTION
* Ubuntu version in documentation to a more recent one
* Suggest using `apt` instead of `apt-get`
* Minor fix in wording

Question:

I actually installed `libfyaml` on Ubuntu 24.04 via `sudo apt install libfyaml-dev` and did not build it from source. I assume for some users the information that this package exists would be helpful. If you want, I can add a paragraph and add a link and instructions.