### PR TITLE
update ternary operator syntax to cross-platform friendly

### DIFF
--- a/src/lib/fy-atom.c
+++ b/src/lib/fy-atom.c
@@ -372,7 +372,7 @@ fy_atom_iter_line_analyze(struct fy_atom_iter *iter, struct fy_atom_iter_line_in
 
 	last_was_ws = false;
 
-	ts = atom->tabsize ? : 8;	/* pick it up from the atom (if there is) */
+	ts = atom->tabsize ? atom->tabsize : 8;	/* pick it up from the atom (if there is) */
 
 	/* consecutive whitespace */
 	cws = 0;
@@ -642,7 +642,7 @@ void fy_atom_iter_start(const struct fy_atom *atom, struct fy_atom_iter *iter)
 	iter->chomp = atom->increment;
 
 	/* default tab size is 8 */
-	iter->tabsize = atom->tabsize ? : 8;
+	iter->tabsize = atom->tabsize ? atom->tabsize : 8;
 
 	memset(iter->li, 0, sizeof(iter->li));
 	li = &iter->li[1];

--- a/src/lib/fy-diag.c
+++ b/src/lib/fy-diag.c
@@ -508,13 +508,13 @@ int fy_vdiag(struct fy_diag *diag, const struct fy_diag_ctx *fydc,
 	}
 
 	rc = fy_diag_printf(diag, "%s" "%*s" "%*s" "%*s" "%*s" "%s" "%s\n",
-			color_start ? : "",
-			source    ? diag->cfg.source_width : 0, source ? : "",
-			position  ? diag->cfg.position_width : 0, position ? : "",
-			typestr   ? diag->cfg.type_width : 0, typestr ? : "",
-			modulestr ? diag->cfg.module_width : 0, modulestr ? : "",
+			color_start ? color_start : "",
+			source    ? diag->cfg.source_width : 0, source ? source : "",
+			position  ? diag->cfg.position_width : 0, position ? position : "",
+			typestr   ? diag->cfg.type_width : 0, typestr ? typestr : "",
+			modulestr ? diag->cfg.module_width : 0, modulestr ? modulestr : "",
 			msg,
-			color_end ? : "");
+			color_end ? color_end : "");
 
 	if (rc > 0)
 		rc++;
@@ -855,7 +855,7 @@ void fy_diag_vreport(struct fy_diag *diag,
 
 	if (!diag->collect_errors) {
 		fy_diag_printf(diag, "%s" "%s%s: %s" "%s\n",
-			name_str ? : "",
+			name_str ? name_str : "",
 			color_start, fy_error_type_to_string(fydrc->type), color_end,
 			msg_str);
 

--- a/src/lib/fy-doc.c
+++ b/src/lib/fy-doc.c
@@ -5867,7 +5867,7 @@ void fy_node_mapping_perform_sort(struct fy_node *fyn_map,
 		def_arg.cmp_fn = NULL;
 		def_arg.arg = NULL;
 	}
-	ctx.key_cmp = key_cmp ? : fy_node_mapping_sort_cmp_default;
+	ctx.key_cmp = key_cmp ? key_cmp : fy_node_mapping_sort_cmp_default;
 	ctx.arg = key_cmp ? arg : &def_arg;
 	ctx.fynpp = fynpp;
 	ctx.count = count;

--- a/src/lib/fy-emit.c
+++ b/src/lib/fy-emit.c
@@ -1900,7 +1900,7 @@ int fy_emit_document_start(struct fy_emitter *emit, struct fy_document *fyd,
 	if (!emit || !fyd || !fyd->fyds)
 		return -1;
 
-	root = fyn_root ? : fy_document_root(fyd);
+	root = fyn_root ? fyn_root : fy_document_root(fyd);
 
 	root_tag_or_anchor = root && (root->tag || fy_document_lookup_anchor_by_node(fyd, root));
 

--- a/src/lib/fy-parse.c
+++ b/src/lib/fy-parse.c
@@ -6876,7 +6876,7 @@ int fy_parser_set_input_fp(struct fy_parser *fyp, const char *name, FILE *fp)
 	memset(&fyic, 0, sizeof(fyic));
 
 	fyic.type = fyit_stream;
-	fyic.stream.name = name ? : "<stream>";
+	fyic.stream.name = name ? name : "<stream>";
 	fyic.stream.fp = fp;
 	fyic.ignore_stdio = !!(fyp->cfg.flags & FYPCF_DISABLE_BUFFERING);
 

--- a/src/lib/fy-parse.h
+++ b/src/lib/fy-parse.h
@@ -582,7 +582,7 @@ fy_parser_set_reader(struct fy_parser *fyp, struct fy_reader *fyr)
 {
 	if (!fyp)
 		return;
-	fyp->reader = fyr ? : &fyp->builtin_reader;
+	fyp->reader = fyr ? fyr : &fyp->builtin_reader;
 }
 
 static inline void


### PR DESCRIPTION
First of a few PRs to get libfyaml closer to cross-platform (focus on Visual Studio).

This PR updates ternary operators that use shorthand syntax (e.g. a ? : b) to use the more explicit syntax required by Visual Studio (e.g. a ? a : b).