### PR TITLE
Various CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ project(fyaml LANGUAGES C VERSION 0.9.1)
 # locations on all platforms.
 include(GNUInstallDirs)
 
+option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+
 set(LIBHDRS
   src/lib/fy-accel.h
   src/lib/fy-atom.h
@@ -82,6 +84,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
     VERSION ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
 )
+set_target_properties(${PROJECT_NAME} PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 target_include_directories(${PROJECT_NAME}
     PUBLIC


### PR DESCRIPTION
Hi!

This PR (along with some minor formatting fixes) changes two things:
 * The version number is now propagated properly when building with CMake, so libfyaml won't report different version numbers depending whether it was compiled with automake or cmake
 * The toggle for shared/static libraries is now made explicit, which is a rather common pattern for cmake projects that allow both using the standard cmake options. It defaults to building the shared library.

In the long run, making the cmake project also generate the pkgconf file like Automake does would be nice, then it would achieve full feature-party. But that's for later.

I hope you find these changes useful!
Cheers,
    Matthias
