### PR TITLE
util: use <endian.h> also on GNU/Hurd

### DIFF
--- a/src/util/fy-endian.h
+++ b/src/util/fy-endian.h
@@ -8,7 +8,7 @@
 #ifndef FY_ENDIAN_H
 #define FY_ENDIAN_H
 
-#if defined(__linux__) || defined(__CYGWIN__) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__OpenBSD__) || defined(__GNU__)
 # include <endian.h>
 #elif defined(__APPLE__)
 # include <libkern/OSByteOrder.h>


### PR DESCRIPTION
The Hurd uses GNU libc, which provides `<endian.h>`.