### PR TITLE
Fix ctype(3) arguments

### DIFF
--- a/src/internal/fy-b3sum.c
+++ b/src/internal/fy-b3sum.c
@@ -233,12 +233,12 @@ static int do_check_file(struct blake3_hasher *hasher, const char *check_filenam
 
 		length = 0;
 		s = linebuf;
-		while (isxdigit(*s))
+		while (isxdigit((unsigned char)*s))
 			s++;
 
 		length = s - linebuf;
 
-		if (length == 0 || length > (BLAKE3_OUT_LEN * 2) || (length % 1) || !isspace(*s)) {
+		if (length == 0 || length > (BLAKE3_OUT_LEN * 2) || (length % 1) || !isspace((unsigned char)*s)) {
 			fprintf(stderr, "Bad line found at file \"%s\" line #%d\n", check_filename, line);
 			fprintf(stderr, "%s\n", linebuf);
 			goto err_out;
@@ -246,7 +246,7 @@ static int do_check_file(struct blake3_hasher *hasher, const char *check_filenam
 
 		*s++ = '\0';
 
-		while (isspace(*s))
+		while (isspace((unsigned char)*s))
 			s++;
 
 		length >>= 1;	/* to bytes */

--- a/src/lib/fy-diag.c
+++ b/src/lib/fy-diag.c
@@ -52,7 +52,7 @@ enum fy_error_type fy_string_to_error_type(const char *str)
 	if (!str)
 		return FYET_MAX;
 
-	if (isdigit(*str)) {
+	if (isdigit((unsigned char)*str)) {
 		level = atoi(str);
 		if (level >= 0 && level < FYET_MAX)
 			return (enum fy_error_type)level;

--- a/src/lib/fy-doc.c
+++ b/src/lib/fy-doc.c
@@ -4186,7 +4186,7 @@ fy_node_by_path_internal(struct fy_node *fyn,
 		switch (ptr_flags) {
 		default:
 		case FYNWF_PTR_YAML:
-			while (s < e && isspace(*s))
+			while (s < e && isspace((unsigned char)*s))
 				s++;
 
 			c = *s;
@@ -4203,13 +4203,13 @@ fy_node_by_path_internal(struct fy_node *fyn,
 
 			s = end_idx;
 
-			while (s < e && isspace(*s))
+			while (s < e && isspace((unsigned char)*s))
 				s++;
 
 			if (c == '[' && *s++ != ']')
 				return NULL;
 
-			while (s < e && isspace(*s))
+			while (s < e && isspace((unsigned char)*s))
 				s++;
 
 			break;
@@ -4480,7 +4480,7 @@ struct fy_node *fy_node_by_path(struct fy_node *fyn,
 
 	/* first path component may be an alias */
 	if ((flags & FYNWF_FOLLOW) && fyn && path) {
-		while (s < e && isspace(*s))
+		while (s < e && isspace((unsigned char)*s))
 			s++;
 
 		if (s >= e || *s != '*')
@@ -6248,10 +6248,10 @@ int fy_node_vscanf(struct fy_node *fyn, const char *fmt, va_list ap)
 		}
 
 		/* trim spaces from key */
-		while (isspace(*s))
+		while (isspace((unsigned char)*s))
 			s++;
 		te = t;
-		while (te > s && isspace(te[-1]))
+		while (te > s && isspace((unsigned char)te[-1]))
 			*--te = '\0';
 
 		key = s;
@@ -6259,7 +6259,7 @@ int fy_node_vscanf(struct fy_node *fyn, const char *fmt, va_list ap)
 		/* we have to scan until the next space that's not in char set */
 		fmtspec = t;
 		while (t < e) {
-			if (isspace(*t))
+			if (isspace((unsigned char)*t))
 				break;
 			/* character set (may include space) */
 			if (*t == '[') {

--- a/src/tool/fy-tool.c
+++ b/src/tool/fy-tool.c
@@ -871,12 +871,12 @@ static int do_b3sum_check_file(struct fy_blake3_hasher *hasher, const char *chec
 
 		length = 0;
 		s = linebuf;
-		while (isxdigit(*s))
+		while (isxdigit((unsigned char)*s))
 			s++;
 
 		length = s - linebuf;
 
-		if (length == 0 || length > (FY_BLAKE3_OUT_LEN * 2) || (length % 1) || !isspace(*s)) {
+		if (length == 0 || length > (FY_BLAKE3_OUT_LEN * 2) || (length % 1) || !isspace((unsigned char)*s)) {
 			fprintf(stderr, "Bad line found at file \"%s\" line #%d\n", check_filename, line);
 			fprintf(stderr, "%s\n", linebuf);
 			goto err_out;
@@ -884,7 +884,7 @@ static int do_b3sum_check_file(struct fy_blake3_hasher *hasher, const char *chec
 
 		*s++ = '\0';
 
-		while (isspace(*s))
+		while (isspace((unsigned char)*s))
 			s++;
 
 		length >>= 1;	/* to bytes */

--- a/src/util/fy-utils.c
+++ b/src/util/fy-utils.c
@@ -675,7 +675,7 @@ again:
 	e = iter->end;
 
 	/* skip whitespace */
-	while (s < e && isblank(*s))
+	while (s < e && isblank((unsigned char)*s))
 		s++;
 
 	if (s >= e)
@@ -695,12 +695,12 @@ again:
 		le -= 2;
 
 	/* backtrack while there's space at the end of line */
-	while (le > s && isblank(le[-1]))
+	while (le > s && isblank((unsigned char)le[-1]))
 		le--;
 
 	/* check if the whole line is punctuation so it's formatting */
 	t = s;
-	while (t < le && ispunct(*t))
+	while (t < le && ispunct((unsigned char)*t))
 		t++;
 
 	/* everything is punctuation? */
@@ -715,11 +715,11 @@ again:
 	}
 
 	/* something is there, skip over '// ' or '* ' */
-	if ((le - s) > 3 && s[0] == '/' && s[1] == '/' && isblank(s[2]))
+	if ((le - s) > 3 && s[0] == '/' && s[1] == '/' && isblank((unsigned char)s[2]))
 		s += 3;
-	else if ((le - s) > 2 && s[0] == '*' && isblank(s[1]))
+	else if ((le - s) > 2 && s[0] == '*' && isblank((unsigned char)s[1]))
 		s += 2;
-	else if (iter->line == 0 && (le - s) > 3 && s[0] == '/' && s[1] == '*' && isblank(s[2]))
+	else if (iter->line == 0 && (le - s) > 3 && s[0] == '/' && s[1] == '*' && isblank((unsigned char)s[2]))
 		s += 3;
 
 	iter->line++;


### PR DESCRIPTION
NetBSD is very picky about the arguments being 'unsigned char's or EOF,
so add casts to make sure about this.
See the CAVEATS in https://man.netbsd.org/ctype.3 for more details.