### PR TITLE
Emit right-comments on flow collection end tokens

### DIFF
--- a/src/lib/fy-emit.c
+++ b/src/lib/fy-emit.c
@@ -1688,6 +1688,10 @@ void fy_emit_sequence(struct fy_emitter *emit, struct fy_node *fyn, int flags, i
 	}
 
 	fy_emit_sequence_epilog(emit, sc);
+
+	/* emit right-comment attached to the closing bracket token */
+	if (fy_emit_token_has_comment(emit, fyn->sequence_end, fycp_right))
+		fy_emit_token_comment(emit, fyn->sequence_end, sc->flags, sc->indent, fycp_right);
 }
 
 static void fy_emit_mapping_prolog(struct fy_emitter *emit, struct fy_emit_save_ctx *sc,
@@ -1997,6 +2001,10 @@ void fy_emit_mapping(struct fy_emitter *emit, struct fy_node *fyn, int flags, in
 		free(fynpp);
 
 	fy_emit_mapping_epilog(emit, sc);
+
+	/* emit right-comment attached to the closing brace token */
+	if (fy_emit_token_has_comment(emit, fyn->mapping_end, fycp_right))
+		fy_emit_token_comment(emit, fyn->mapping_end, sc->flags, sc->indent, fycp_right);
 
 err_out:
 	return;

--- a/test/libfyaml-test-emit.c
+++ b/test/libfyaml-test-emit.c
@@ -389,6 +389,46 @@ START_TEST(emit_indented_seq_in_map_default)
 }
 END_TEST
 
+START_TEST(emit_right_comment_on_flow_sequence_value)
+{
+	struct fy_parse_cfg cfg = { .flags = FYPCF_PARSE_COMMENTS };
+	struct fy_document *fyd;
+	char *output;
+
+	fyd = fy_document_build_from_string(&cfg,
+		"colors: [red, green] # primary\ncount: 3\n", FY_NT);
+	ck_assert_ptr_ne(fyd, NULL);
+
+	output = fy_emit_document_to_string(fyd,
+		FYECF_MODE_ORIGINAL | FYECF_OUTPUT_COMMENTS);
+	ck_assert_ptr_ne(output, NULL);
+	ck_assert_ptr_ne(strstr(output, "# primary"), NULL);
+
+	free(output);
+	fy_document_destroy(fyd);
+}
+END_TEST
+
+START_TEST(emit_right_comment_on_flow_mapping_value)
+{
+	struct fy_parse_cfg cfg = { .flags = FYPCF_PARSE_COMMENTS };
+	struct fy_document *fyd;
+	char *output;
+
+	fyd = fy_document_build_from_string(&cfg,
+		"settings: {verbose: true} # defaults\n", FY_NT);
+	ck_assert_ptr_ne(fyd, NULL);
+
+	output = fy_emit_document_to_string(fyd,
+		FYECF_MODE_ORIGINAL | FYECF_OUTPUT_COMMENTS);
+	ck_assert_ptr_ne(output, NULL);
+	ck_assert_ptr_ne(strstr(output, "# defaults"), NULL);
+
+	free(output);
+	fy_document_destroy(fyd);
+}
+END_TEST
+
 void libfyaml_case_emit(struct fy_check_suite *cs)
 {
 	struct fy_check_testcase *ctc;
@@ -408,4 +448,6 @@ void libfyaml_case_emit(struct fy_check_suite *cs)
 	fy_check_testcase_add_test(ctc, emit_comment_no_duplicate_seq_in_mapping);
 	fy_check_testcase_add_test(ctc, emit_indented_seq_in_map);
 	fy_check_testcase_add_test(ctc, emit_indented_seq_in_map_default);
+	fy_check_testcase_add_test(ctc, emit_right_comment_on_flow_sequence_value);
+	fy_check_testcase_add_test(ctc, emit_right_comment_on_flow_mapping_value);
 }


### PR DESCRIPTION
If you have a flow mapping or sequence like the following with right hand comments

```yaml
alphabet: ["a", "b", "c"] # You can't say many words with this
# or
my_map: {"a": 1, "b": 2, "c": 3} # This is a small map
```

The comments get parsed and stored on the right tokens but they never get emitted, so have a added a check into the sequence/mapping epilogs that emits those comments if they exist. Have also added some extra tests to prove this works

