### PR TITLE
Allow comments before first entry in a nest block mapping or sequence to be emitted

### DIFF
--- a/src/lib/fy-emit.c
+++ b/src/lib/fy-emit.c
@@ -1557,9 +1557,8 @@ static void fy_emit_sequence_prolog(struct fy_emitter *emit, struct fy_emit_save
 	bool json = fy_emit_is_json_mode(emit);
 	bool was_flow = sc->flow;
 
-	/* only emit top comment at root level; for nested containers the
-	 * parent item prolog has already emitted it */
-	if ((sc->flags & DDNF_ROOT) && fy_emit_token_has_comment(emit, fyt, fycp_top)) {
+	/* skip top comment if parent sequence_item_prolog already emitted it */
+	if (!(sc->flags & DDNF_SEQ) && fy_emit_token_has_comment(emit, fyt, fycp_top)) {
 		fy_emit_token_comment(emit, fyt, sc->flags, sc->indent, fycp_top);
 		sc->flags |= DDNF_HANGING_INDENT;
 	}
@@ -1700,9 +1699,8 @@ static void fy_emit_mapping_prolog(struct fy_emitter *emit, struct fy_emit_save_
 	bool json = fy_emit_is_json_mode(emit);
 	bool was_flow = sc->flow;
 
-	/* only emit top comment at root level; for nested containers the
-	 * parent item prolog has already emitted it */
-	if ((sc->flags & DDNF_ROOT) && fy_emit_token_has_comment(emit, fyt, fycp_top)) {
+	/* skip top comment if parent sequence_item_prolog already emitted it */
+	if (!(sc->flags & DDNF_SEQ) && fy_emit_token_has_comment(emit, fyt, fycp_top)) {
 		fy_emit_token_comment(emit, fyt, sc->flags, sc->indent, fycp_top);
 		sc->flags |= DDNF_HANGING_INDENT;
 	}

--- a/test/libfyaml-test-emit.c
+++ b/test/libfyaml-test-emit.c
@@ -429,6 +429,82 @@ START_TEST(emit_right_comment_on_flow_mapping_value)
 }
 END_TEST
 
+START_TEST(emit_nested_mapping_top_comment)
+{
+	struct fy_parse_cfg cfg = { .flags = FYPCF_PARSE_COMMENTS };
+	struct fy_document *fyd;
+	char *output;
+
+	fyd = fy_document_build_from_string(&cfg,
+		"jobs:\n  build:\n    # comment before runs-on\n    runs-on: ubuntu-latest\n", FY_NT);
+	ck_assert_ptr_ne(fyd, NULL);
+
+	output = fy_emit_document_to_string(fyd, FYECF_OUTPUT_COMMENTS);
+	ck_assert_ptr_ne(output, NULL);
+	ck_assert_ptr_ne(strstr(output, "# comment before runs-on"), NULL);
+
+	free(output);
+	fy_document_destroy(fyd);
+}
+END_TEST
+
+START_TEST(emit_nested_sequence_top_comment)
+{
+	struct fy_parse_cfg cfg = { .flags = FYPCF_PARSE_COMMENTS };
+	struct fy_document *fyd;
+	char *output;
+
+	fyd = fy_document_build_from_string(&cfg,
+		"parent:\n  # comment before first item\n  - item1\n  - item2\n", FY_NT);
+	ck_assert_ptr_ne(fyd, NULL);
+
+	output = fy_emit_document_to_string(fyd, FYECF_OUTPUT_COMMENTS);
+	ck_assert_ptr_ne(output, NULL);
+	ck_assert_ptr_ne(strstr(output, "# comment before first item"), NULL);
+
+	free(output);
+	fy_document_destroy(fyd);
+}
+END_TEST
+
+START_TEST(emit_deeply_nested_top_comment)
+{
+	struct fy_parse_cfg cfg = { .flags = FYPCF_PARSE_COMMENTS };
+	struct fy_document *fyd;
+	char *output;
+
+	fyd = fy_document_build_from_string(&cfg,
+		"a:\n  b:\n    c:\n      # deep comment\n      d: value\n", FY_NT);
+	ck_assert_ptr_ne(fyd, NULL);
+
+	output = fy_emit_document_to_string(fyd, FYECF_OUTPUT_COMMENTS);
+	ck_assert_ptr_ne(output, NULL);
+	ck_assert_ptr_ne(strstr(output, "# deep comment"), NULL);
+
+	free(output);
+	fy_document_destroy(fyd);
+}
+END_TEST
+
+START_TEST(emit_root_top_comment_still_works)
+{
+	struct fy_parse_cfg cfg = { .flags = FYPCF_PARSE_COMMENTS };
+	struct fy_document *fyd;
+	char *output;
+
+	fyd = fy_document_build_from_string(&cfg,
+		"# root comment\nkey: value\n", FY_NT);
+	ck_assert_ptr_ne(fyd, NULL);
+
+	output = fy_emit_document_to_string(fyd, FYECF_OUTPUT_COMMENTS);
+	ck_assert_ptr_ne(output, NULL);
+	ck_assert_ptr_ne(strstr(output, "# root comment"), NULL);
+
+	free(output);
+	fy_document_destroy(fyd);
+}
+END_TEST
+
 void libfyaml_case_emit(struct fy_check_suite *cs)
 {
 	struct fy_check_testcase *ctc;
@@ -450,4 +526,8 @@ void libfyaml_case_emit(struct fy_check_suite *cs)
 	fy_check_testcase_add_test(ctc, emit_indented_seq_in_map_default);
 	fy_check_testcase_add_test(ctc, emit_right_comment_on_flow_sequence_value);
 	fy_check_testcase_add_test(ctc, emit_right_comment_on_flow_mapping_value);
+	fy_check_testcase_add_test(ctc, emit_nested_mapping_top_comment);
+	fy_check_testcase_add_test(ctc, emit_nested_sequence_top_comment);
+	fy_check_testcase_add_test(ctc, emit_deeply_nested_top_comment);
+	fy_check_testcase_add_test(ctc, emit_root_top_comment_still_works);
 }


### PR DESCRIPTION
At the minute these comments are captured by the parser, and stored on the right lexical elements but don't get emitted due to `DDNF_ROOT` not getting set for nested containers. Updates the guard so these elements can be emitted.