### PR TITLE
cmake: replace CMAKE_SOURCE_DIR with CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -971,7 +971,7 @@ endif()
 add_libclang_to_target(fyaml_static INTERFACE)
 
 # check if blocks are available, and if so link them
-include(${CMAKE_SOURCE_DIR}/cmake/CheckClangBlocks.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CheckClangBlocks.cmake)
 
 # Apply flags if available
 if (HAVE_CLANG_BLOCKS)


### PR DESCRIPTION
I was trying to compile libfyaml as a submodule and noticed it wasn't configuring when included with `add_subdirectory(path/to/libfyaml)`. I was getting this error.
```
CMake Error at path/to/libfyaml/CMakeLists.txt:974 (include):
  include could not find requested file:

    (project_root)/cmake/CheckClangBlocks.cmake
```

https://github.com/pantoniou/libfyaml/blob/5591f8e8ccdedcfbc0d099c216c1c2dfcfe9a15a/CMakeLists.txt#L974

This was the line with causing cmake to look for `CheckClangBlocks.cmake` in my project's root directory instead of libfyaml's. Using CMAKE_SOURCE_DIR here seems like a mistype because replacing it with CMAKE_CURRENT_SOURCE_DIR made no difference in compiling libfyaml itself.