### PR TITLE
Fix folded block scalar line breaks being lost

### DIFF
--- a/src/lib/fy-emit.c
+++ b/src/lib/fy-emit.c
@@ -119,6 +119,13 @@ static inline bool fy_emit_is_pretty_mode(const struct fy_emitter *emit)
 	return flags == FYECF_MODE_PRETTY;
 }
 
+static inline bool fy_emit_is_original_mode(const struct fy_emitter *emit)
+{
+	enum fy_emitter_cfg_flags flags = emit->xcfg.cfg.flags & FYECF_MODE(FYECF_MODE_MASK);
+
+	return flags == FYECF_MODE_ORIGINAL;
+}
+
 static inline bool fy_emit_is_manual(const struct fy_emitter *emit)
 {
 	enum fy_emitter_cfg_flags flags = emit->xcfg.cfg.flags & FYECF_MODE(FYECF_MODE_MASK);
@@ -1293,6 +1300,68 @@ out:
 	emit->flags &= ~FYEF_INDENTATION;
 }
 
+static inline bool fy_emit_can_use_original_folded_breaks(struct fy_emitter *emit,
+                                                          struct fy_atom *atom)
+{
+	return fy_emit_is_original_mode(emit) && atom->fyi &&
+	       atom->chomp_explicit &&
+	       (atom->style & ~FYAS_MANUAL_MARK) == FYAS_FOLDED;
+}
+
+static void fy_emit_token_write_folded_original(struct fy_emitter *emit,
+                                                struct fy_token *fyt, struct fy_atom *atom, int indent)
+{
+	struct fy_atom_raw_line_iter rliter;
+	const struct fy_raw_line *rl;
+	int w;
+
+	fy_atom_raw_line_iter_start(atom, &rliter);
+	fy_emit_accum_start(&emit->ea, emit->column, fy_token_atom_lb_mode(fyt));
+
+	const unsigned int orig_indent = atom->increment;
+
+	while ((rl = fy_atom_raw_line_iter_next(&rliter)) != NULL) {
+
+		if (rl->content_len == 0) {
+			/* blank line: emit newline only */
+			fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+			emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+			continue;
+		}
+
+		/* content line: write indent, content, then newline */
+		fy_emit_write_indent(emit, indent);
+		fy_emit_output_col_sync(emit, &emit->ea);
+
+		const char *s = rl->content_start;
+		const char *e = s + rl->content_len;
+
+		/* skip the block scalar's base indentation */
+		{
+			unsigned int skip = orig_indent;
+			while (skip > 0 && s < e &&
+			       (!atom->tabsize ? (*s == ' ') : fy_utf8_is_ws((unsigned char)*s))) {
+				s++;
+				skip--;
+			}
+		}
+
+		while (s < e) {
+			const int c = fy_utf8_get(s, (size_t) (e - s), &w);
+			if (c <= 0)
+				break;
+			fy_emit_accum_utf8_put(&emit->ea, c);
+			s += w;
+		}
+		fy_emit_output_accum(emit, fyewt_folded_scalar, &emit->ea);
+		fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+		emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+	}
+
+	fy_emit_accum_finish(&emit->ea);
+	fy_atom_raw_line_iter_finish(&rliter);
+}
+
 void fy_emit_token_write_folded(struct fy_emitter *emit, struct fy_token *fyt, int flags, int indent)
 {
 	bool leading_spaces, breaks;
@@ -1313,6 +1382,13 @@ void fy_emit_token_write_folded(struct fy_emitter *emit, struct fy_token *fyt, i
 	atom = fy_token_atom(fyt);
 	if (!atom)
 		return;
+
+	/* in original mode with a parsed-as-folded atom, preserve original line breaks;
+	 * chomp_explicit distinguishes parsed block scalars from event-created atoms */
+	if (fy_emit_can_use_original_folded_breaks(emit, atom)) {
+		fy_emit_token_write_folded_original(emit, fyt, atom, indent);
+		return;
+	}
 
 	breaks = true;
 	leading_spaces = true;

--- a/test/libfyaml-test-emit-bugs.c
+++ b/test/libfyaml-test-emit-bugs.c
@@ -842,6 +842,77 @@ START_TEST(emit_bug_comment_indent_seq_in_map_multiline)
 }
 END_TEST
 
+/* ═══════════════════════════════════════════════════════════════════
+ * Bug 15: Folded block scalar line breaks lost on re-emit
+ *
+ * Folded scalars (>, >-, >+) lose their original line break positions
+ * during a parse→emit round-trip in original mode.
+ * ═══════════════════════════════════════════════════════════════════ */
+
+/* parse→emit round-trip helper: returns emitted string (caller frees) */
+static char *roundtrip_doc(const char *input)
+{
+	struct fy_document *fyd;
+	char *buf;
+
+	fyd = fy_document_build_from_string(NULL, input, FY_NT);
+	if (!fyd)
+		return NULL;
+	buf = fy_emit_document_to_string(fyd, FYECF_DEFAULT);
+	fy_document_destroy(fyd);
+	return buf;
+}
+
+START_TEST(emit_bug_folded_clip_roundtrip)
+{
+	const char input[] = "run: >\n  line one\n  line two\n";
+	char *buf = roundtrip_doc(input);
+	ck_assert_ptr_ne(buf, NULL);
+	ck_assert_str_eq(buf, input);
+	free(buf);
+}
+END_TEST
+
+START_TEST(emit_bug_folded_strip_roundtrip)
+{
+	const char input[] = "run: >-\n  line one\n  line two\n";
+	char *buf = roundtrip_doc(input);
+	ck_assert_ptr_ne(buf, NULL);
+	ck_assert_str_eq(buf, input);
+	free(buf);
+}
+END_TEST
+
+START_TEST(emit_bug_folded_keep_roundtrip)
+{
+	const char input[] = "run: >+\n  line one\n  line two\n\n";
+	char *buf = roundtrip_doc(input);
+	ck_assert_ptr_ne(buf, NULL);
+	ck_assert_str_eq(buf, input);
+	free(buf);
+}
+END_TEST
+
+START_TEST(emit_bug_folded_blank_lines_roundtrip)
+{
+	const char input[] = "run: >\n  line one\n\n  line three\n";
+	char *buf = roundtrip_doc(input);
+	ck_assert_ptr_ne(buf, NULL);
+	ck_assert_str_eq(buf, input);
+	free(buf);
+}
+END_TEST
+
+START_TEST(emit_bug_folded_more_indented_roundtrip)
+{
+	const char input[] = "run: >\n  normal\n    indented\n  back\n";
+	char *buf = roundtrip_doc(input);
+	ck_assert_ptr_ne(buf, NULL);
+	ck_assert_str_eq(buf, input);
+	free(buf);
+}
+END_TEST
+
 /* ── registration ────────────────────────────────────────────────── */
 
 void libfyaml_case_emit_bugs(struct fy_check_suite *cs)
@@ -916,4 +987,11 @@ void libfyaml_case_emit_bugs(struct fy_check_suite *cs)
 
 	/* other kind of emit bugs */
 	fy_check_testcase_add_test(ctc, emit_bug_unquoted_flow_comma);
+
+	/* Bug 15: folded block scalar line breaks lost on re-emit */
+	fy_check_testcase_add_test(ctc, emit_bug_folded_clip_roundtrip);
+	fy_check_testcase_add_test(ctc, emit_bug_folded_strip_roundtrip);
+	fy_check_testcase_add_test(ctc, emit_bug_folded_keep_roundtrip);
+	fy_check_testcase_add_test(ctc, emit_bug_folded_blank_lines_roundtrip);
+	fy_check_testcase_add_test(ctc, emit_bug_folded_more_indented_roundtrip);
 }


### PR DESCRIPTION
If we're in original mode then we should expect line breaks in block scalars to be retained, i.e.

```yaml
run: >
  this is a long line
  that will be folded
  into a single line
```
Should come out the same, but at the moment it comes as 

```yaml
run: >
  this is a long line that will be folded into a single line
```

The problem is that when `fy_atom_iter_line_analyze` is called and it's the `FYAS_FOLDED` case two adjacent, non-empty content lines produce a space between them and thus the new-lines get lost. The solution is instead to iterate over the raw bytes in original mode so we can get the line-breaks back.