### PR TITLE
cmake: Respect DESTDIR when creating symlinks to fy-tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1473,12 +1473,12 @@ install(TARGETS fyaml fy-tool
 # Create symlinks for fy-tool (not on Windows - symlinks require special privileges)
 if(NOT WIN32)
     install(CODE "
-        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink fy-tool fy-dump WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})
-        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink fy-tool fy-filter WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})
-        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink fy-tool fy-testsuite WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})
-        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink fy-tool fy-join WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})
-        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink fy-tool fy-ypath WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})
-        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink fy-tool fy-compose WORKING_DIRECTORY \${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR})
+        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink fy-tool fy-dump WORKING_DIRECTORY \$ENV{DESTDIR}/${CMAKE_INSTALL_FULL_BINDIR})
+        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink fy-tool fy-filter WORKING_DIRECTORY \$ENV{DESTDIR}/${CMAKE_INSTALL_FULL_BINDIR})
+        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink fy-tool fy-testsuite WORKING_DIRECTORY \$ENV{DESTDIR}/${CMAKE_INSTALL_FULL_BINDIR})
+        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink fy-tool fy-join WORKING_DIRECTORY \$ENV{DESTDIR}/${CMAKE_INSTALL_FULL_BINDIR})
+        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink fy-tool fy-ypath WORKING_DIRECTORY \$ENV{DESTDIR}/${CMAKE_INSTALL_FULL_BINDIR})
+        execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink fy-tool fy-compose WORKING_DIRECTORY \$ENV{DESTDIR}/${CMAKE_INSTALL_FULL_BINDIR})
     ")
 endif()
 


### PR DESCRIPTION
Also simplify CMAKE_INSTALL_PREFIX/CMAKE_INSTALL_BINDIR to CMAKE_INSTALL_FULL_BINDIR, which basically is just CMAKE_INSTALL_BINDIR prepended with CMAKE_INSTALL_PREFIX.