### PR TITLE
utils: fix overflow implementations

### DIFF
--- a/src/tool/fy-tool-util.h
+++ b/src/tool/fy-tool-util.h
@@ -99,7 +99,7 @@ static inline bool fy_add_overflow_size_t(size_t a, size_t b, size_t *resp)
 	\
 	__res = __a + __b; \
 	/* overflow when signs of a, b same, but results different */ \
-	__overflow = ((__a ^ __result) & (__b & __result)) < 0; \
+	__overflow = ((__a ^ __res) & (__b & __res)) < 0; \
 	*(_resp) = __res; \
 	__overflow; \
 })
@@ -132,7 +132,7 @@ static inline bool fy_sub_overflow_size_t(size_t a, size_t b, size_t *resp)
 	\
 	__res = __a - __b; \
 	/* overflow when signs of a, b differ, but results different from minuend */ \
-	__overflow = ((__a ^ __b) & (__a & __result)) < 0; \
+	__overflow = ((__a ^ __b) & (__a & __res)) < 0; \
 	*(_resp) = __res; \
 	__overflow; \
 })

--- a/src/util/fy-utils.h
+++ b/src/util/fy-utils.h
@@ -229,7 +229,7 @@ void fy_keyword_iter_end(struct fy_keyword_iter *iter);
 	\
 	__res = __a + __b; \
 	/* overflow when signs of a, b same, but results different */ \
-	__overflow = ((__a ^ __result) & (__b & __result)) < 0; \
+	__overflow = ((__a ^ __res) & (__b & __res)) < 0; \
 	*(_resp) = __res; \
 	__overflow; \
 })
@@ -255,7 +255,7 @@ void fy_keyword_iter_end(struct fy_keyword_iter *iter);
 	\
 	__res = __a - __b; \
 	/* overflow when signs of a, b differ, but results different from minuend */ \
-	__overflow = ((__a ^ __b) & (__a & __result)) < 0; \
+	__overflow = ((__a ^ __b) & (__a & __res)) < 0; \
 	*(_resp) = __res; \
 	__overflow; \
 })


### PR DESCRIPTION
Fix compile errors in the custom overflow macros, e.g.:
```
 src/util/fy-utils.h:232:23: error: '__result' undeclared (first use in
                                  this function); did you mean '__res'?
   __overflow = ((__a ^ __result) & (__b & __result)) < 0; \
```
This happens for any gcc version less than 10, as they do not have `__has_builtin` and therefor are falling back to the custom macros.