### PR TITLE
Fix folded scalars emitting extra blank lines in Original mode

### DIFF
--- a/src/lib/fy-emit.c
+++ b/src/lib/fy-emit.c
@@ -1313,6 +1313,7 @@ static void fy_emit_token_write_folded_original(struct fy_emitter *emit,
 	struct fy_atom_raw_line_iter rliter;
 	const struct fy_raw_line *rl;
 	int w;
+	int deferred_blanks = 0;
 
 	fy_atom_raw_line_iter_start(atom, &rliter);
 	fy_emit_accum_start(&emit->ea, emit->column, fy_token_atom_lb_mode(fyt));
@@ -1321,21 +1322,14 @@ static void fy_emit_token_write_folded_original(struct fy_emitter *emit,
 
 	while ((rl = fy_atom_raw_line_iter_next(&rliter)) != NULL) {
 
-		if (rl->content_len == 0) {
-			/* blank line: emit newline only */
-			fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
-			emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
-			continue;
-		}
+		/* Partial final fragment: parser lookahead consumed indent bytes of the
+		 * next element; no trailing linebreak means this is not scalar content. */
+		if (rl->line_len_lb == rl->line_len)
+			break;
 
-		/* content line: write indent, content, then newline */
-		fy_emit_write_indent(emit, indent);
-		fy_emit_output_col_sync(emit, &emit->ea);
-
+		/* Compute content after stripping base indentation */
 		const char *s = rl->content_start;
 		const char *e = s + rl->content_len;
-
-		/* skip the block scalar's base indentation */
 		{
 			unsigned int skip = orig_indent;
 			while (skip > 0 && s < e &&
@@ -1345,8 +1339,24 @@ static void fy_emit_token_write_folded_original(struct fy_emitter *emit,
 			}
 		}
 
+		if (s >= e) {
+			/* blank line: defer emission */
+			deferred_blanks++;
+			continue;
+		}
+
+		/* non-blank content line: flush any deferred blank lines first */
+		while (deferred_blanks > 0) {
+			fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+			emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+			deferred_blanks--;
+		}
+
+		fy_emit_write_indent(emit, indent);
+		fy_emit_output_col_sync(emit, &emit->ea);
+
 		while (s < e) {
-			const int c = fy_utf8_get(s, (size_t) (e - s), &w);
+			const int c = fy_utf8_get(s, (size_t)(e - s), &w);
 			if (c <= 0)
 				break;
 			fy_emit_accum_utf8_put(&emit->ea, c);
@@ -1355,6 +1365,15 @@ static void fy_emit_token_write_folded_original(struct fy_emitter *emit,
 		fy_emit_output_accum(emit, fyewt_folded_scalar, &emit->ea);
 		fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
 		emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+	}
+
+	/* trailing blank lines: only keep-chomp retains them */
+	if (atom->chomp == FYAC_KEEP) {
+		while (deferred_blanks > 0) {
+			fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+			emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
+			deferred_blanks--;
+		}
 	}
 
 	fy_emit_accum_finish(&emit->ea);

--- a/test/libfyaml-test-emit-bugs.c
+++ b/test/libfyaml-test-emit-bugs.c
@@ -913,6 +913,67 @@ START_TEST(emit_bug_folded_more_indented_roundtrip)
 }
 END_TEST
 
+/* ═══ Bug 16: fy_emit_token_write_folded_original emits spurious blank line ═══ */
+
+START_TEST(emit_bug_folded_clip_no_trailing_blank)
+{
+    /* >  (clip): roundtrip must not add a blank line after the scalar */
+    static const char input[] =
+        "key: >\n"
+        "  content line\n"
+        "other: value\n";
+    char *got = roundtrip_doc(input);
+    ck_assert_ptr_ne(got, NULL);
+    ck_assert_str_eq(got, input);
+    free(got);
+}
+END_TEST
+
+START_TEST(emit_bug_folded_strip_no_trailing_blank)
+{
+    /* >- (strip): roundtrip must not add a blank line after the scalar */
+    static const char input[] =
+        "key: >-\n"
+        "  content line\n"
+        "other: value\n";
+    char *got = roundtrip_doc(input);
+    ck_assert_ptr_ne(got, NULL);
+    ck_assert_str_eq(got, input);
+    free(got);
+}
+END_TEST
+
+START_TEST(emit_bug_folded_keep_trailing_blank_preserved)
+{
+    /* >+ (keep): trailing blank lines must be preserved */
+    static const char input[] =
+        "key: >+\n"
+        "  content line\n"
+        "\n"
+        "other: value\n";
+    char *got = roundtrip_doc(input);
+    ck_assert_ptr_ne(got, NULL);
+    ck_assert_str_eq(got, input);
+    free(got);
+}
+END_TEST
+
+START_TEST(emit_bug_folded_mid_content_blank_preserved)
+{
+    /* mid-content blank lines must always be preserved regardless of chomp */
+    static const char input[] =
+        "key: >\n"
+        "  first line\n"
+        "\n"
+        "  second line\n"
+        "other: value\n";
+    char *got = roundtrip_doc(input);
+    ck_assert_ptr_ne(got, NULL);
+    ck_assert_str_eq(got, input);
+    free(got);
+}
+END_TEST
+
 /* ── registration ────────────────────────────────────────────────── */
 
 void libfyaml_case_emit_bugs(struct fy_check_suite *cs)
@@ -994,4 +1055,10 @@ void libfyaml_case_emit_bugs(struct fy_check_suite *cs)
 	fy_check_testcase_add_test(ctc, emit_bug_folded_keep_roundtrip);
 	fy_check_testcase_add_test(ctc, emit_bug_folded_blank_lines_roundtrip);
 	fy_check_testcase_add_test(ctc, emit_bug_folded_more_indented_roundtrip);
+
+	/* Bug 16: folded scalar spurious trailing blank line */
+	fy_check_testcase_add_test(ctc, emit_bug_folded_clip_no_trailing_blank);
+	fy_check_testcase_add_test(ctc, emit_bug_folded_strip_no_trailing_blank);
+	fy_check_testcase_add_test(ctc, emit_bug_folded_keep_trailing_blank_preserved);
+	fy_check_testcase_add_test(ctc, emit_bug_folded_mid_content_blank_preserved);
 }


### PR DESCRIPTION
When emitting YAML in Original node, all the folded scalars (>, >-, >+) get an extra trailing line

```yaml
# input         
  run: >
    this is a long line
    that gets folded                                                                                                                                                                                                               
  # re-emitted output (broken)                                                                                                                                                                                                     
  run: >                                                                                                                                                                                                                           
    this is a long line                                                                                                                                                                                                            
    that gets folded   
                       ← spurious extra blank line    
```

It happens because `fy_fetch_block_scalar` calls `fy_scan_block_scalar_indent` after each content line to determine whether the following line belongs to the scalar. That function advances the reader past the indentation spaces of the  
  next YAML element before reporting their column count. `fy_fill_atom_end` is called after the loop exits, so those consumed bytes are included in the atom's raw span.                                                             
   
  `fy_atom_raw_line_iter_next` therefore surfaces a final fragment consisting solely of those lookahead spaces. Because it has no trailing \n line_len_lb == line_len. `fy_emit_token_write_folded_original` does not recognise   
  this: the indent-skip loop exhausts the spaces, leaving nothing to write, but `fy_emit_putc_simple(emit, fyewt_linebreak, '\n')` fires unconditionally.
                                                                                                                                                                                                                                   
  A secondary issue: genuine blank lines between the last content line and the next element are part of the atom's raw span and must be suppressed for strip/clip (>-/>), or preserved for keep (>+). 

As such the fix is both skip the partial final fragment and defer trailing blank lines in a counter and flush or emit depending on the method