### PR TITLE
Fix 32-bit build by removing stray parameter to fy_skip_size32()

### DIFF
--- a/include/libfyaml/libfyaml-vlsize.h
+++ b/include/libfyaml/libfyaml-vlsize.h
@@ -816,7 +816,7 @@ fy_decode_size_nocheck(const uint8_t *start, size_t *sizep)
 static inline const uint8_t *
 fy_skip_size(const uint8_t *start, size_t bufsz)
 {
-	return fy_skip_size32(start, bufsz, &sz);
+	return fy_skip_size32(start, bufsz);
 }
 
 static inline const uint8_t *


### PR DESCRIPTION
Fix 32-bit builds which in version 0.9.6 fails with:

> include/libfyaml/libfyaml-vlsize.h:819:39: error: use of undeclared identifier 'sz'
>  819 |         return fy_skip_size32(start, bufsz, &sz);