### PR TITLE
Literal |+ scalar produces extra newline before following element

### DIFF
--- a/src/lib/fy-emit.c
+++ b/src/lib/fy-emit.c
@@ -1278,25 +1278,26 @@ void fy_emit_token_write_literal(struct fy_emitter *emit, struct fy_token *fyt, 
 	fy_emit_accum_start(&emit->ea, emit->column, fy_token_atom_lb_mode(fyt));
 	while ((c = fy_atom_iter_utf8_get(&iter)) > 0) {
 
-		if (breaks) {
-			fy_emit_write_indent(emit, indent);
-			fy_emit_output_col_sync(emit, &emit->ea);
-			breaks = false;
-		}
-
 		if (fy_is_lb_m(c, fy_token_atom_lb_mode(fyt))) {
 			fy_emit_output_accum(emit, fyewt_literal_scalar, &emit->ea);
-			emit->flags &= ~FYEF_INDENTATION;
+			fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+			emit->flags |= FYEF_WHITESPACE | FYEF_INDENTATION;
 			breaks = true;
-		} else
+		} else {
+			if (breaks) {
+				fy_emit_write_indent(emit, indent);
+				fy_emit_output_col_sync(emit, &emit->ea);
+				breaks = false;
+			}
 			fy_emit_accum_utf8_put(&emit->ea, c);
+		}
 	}
 	fy_emit_output_accum(emit, fyewt_literal_scalar, &emit->ea);
 	fy_emit_accum_finish(&emit->ea);
 	fy_atom_iter_finish(&iter);
 
 out:
-	emit->flags &= ~FYEF_INDENTATION;
+	;
 }
 
 static inline bool fy_emit_can_use_original_folded_breaks(struct fy_emitter *emit,

--- a/test/libfyaml-test-emit-bugs.c
+++ b/test/libfyaml-test-emit-bugs.c
@@ -974,6 +974,39 @@ START_TEST(emit_bug_folded_mid_content_blank_preserved)
 }
 END_TEST
 
+/* ═══ Bug 17: fy_emit_token_write_literal extra newline for |+ ═══ */
+
+START_TEST(emit_bug_literal_keep_no_extra_newline)
+{
+    /* |+ (keep): trailing blank line must not cause extra newline before next element */
+    static const char input[] =
+        "key: |+\n"
+        "  content line\n"
+        "\n"
+        "other: value\n";
+    char *got = roundtrip_doc(input);
+    ck_assert_ptr_ne(got, NULL);
+    ck_assert_str_eq(got, input);
+    free(got);
+}
+END_TEST
+
+START_TEST(emit_bug_literal_keep_multiple_trailing_blanks)
+{
+    /* |+ with multiple trailing blank lines must all be preserved without extras */
+    static const char input[] =
+        "key: |+\n"
+        "  content line\n"
+        "\n"
+        "\n"
+        "other: value\n";
+    char *got = roundtrip_doc(input);
+    ck_assert_ptr_ne(got, NULL);
+    ck_assert_str_eq(got, input);
+    free(got);
+}
+END_TEST
+
 /* ── registration ────────────────────────────────────────────────── */
 
 void libfyaml_case_emit_bugs(struct fy_check_suite *cs)
@@ -1061,4 +1094,8 @@ void libfyaml_case_emit_bugs(struct fy_check_suite *cs)
 	fy_check_testcase_add_test(ctc, emit_bug_folded_strip_no_trailing_blank);
 	fy_check_testcase_add_test(ctc, emit_bug_folded_keep_trailing_blank_preserved);
 	fy_check_testcase_add_test(ctc, emit_bug_folded_mid_content_blank_preserved);
+
+	/* Bug 17: literal |+ extra trailing newline */
+	fy_check_testcase_add_test(ctc, emit_bug_literal_keep_no_extra_newline);
+	fy_check_testcase_add_test(ctc, emit_bug_literal_keep_multiple_trailing_blanks);
 }


### PR DESCRIPTION
When re-emitting YAML in Original mode, `|+` scalars with trailing blank lines produce one extra blank line per trailing blank.

## Example

```yaml
# input — the blank line is part of the |+ scalar (keep-chomp preserves it)
run: |+
  echo hello
  echo world

```

```yaml
# re-emitted output (broken)
run: |+
  echo hello
  echo world

              # spurious extra blank line
```

The cause is essentially because `fy_emit_token_write_literal` uses a lazy-newline strategy, which is fine when the next character is content but it breaks when the next character is a `\n`. To fix it you just have to make sure that each `\n` gets emitted immeadiately and then set `FYEF_WHITESPACE | FYEF_INDENTATION` so the next `write_indent` does not add another one.