### PR TITLE
Fix comment attachment for sort stability and add document-level comment support

### DIFF
--- a/doc/COMMENT-HANDLING.md
+++ b/doc/COMMENT-HANDLING.md
@@ -1,0 +1,163 @@
+# Comment Handling in libfyaml
+
+## Applicability
+
+Comment handling is an **experimental, opt-in** feature. The behaviour
+described in this document is only active when the relevant flags are set:
+
+- **Parsing:** pass `FYPCF_PARSE_COMMENTS` in the parser configuration flags
+  (`fy_parse_cfg.flags`). Without this flag comments are silently discarded
+  during scanning, as the YAML specification requires.
+- **Emitting:** pass `FYECF_OUTPUT_COMMENTS` in the emitter configuration
+  flags (`fy_emitter_cfg.flags`). Without this flag attached comments are
+  ignored during emission even if they were parsed.
+
+Both flags must be set for a full round-trip. Setting only one is valid but
+produces partial behaviour (e.g. parsing and storing comments without
+re-emitting them, which is useful for comment-aware transformation tools).
+
+Comment handling is not applicable in JSON input mode (`FYPCF_JSON_FORCE` or
+`FYPCF_JSON_AUTO` with a `.json` input): JSON does not permit comments.
+
+## YAML specification position
+
+The YAML 1.2.2 specification defines comment syntax in §6.6 (production rules
+[75]–[79]) and specifies that comments are valid as line separators in §6.7.
+However, the spec explicitly excludes comments from the information model:
+
+> "Comments are a presentation detail and must not have any effect on the
+> serialization tree or representation graph."
+> — YAML 1.2.2 §3.2.3.3
+
+The specification gives **no guidance on comment preservation or placement
+during a round-trip (parse → modify → emit) cycle**. This is an intentional
+gap: the spec treats comments as belonging to the serialisation layer only.
+
+libfyaml's comment handling is therefore an implementation extension above and
+beyond the specification. The rules described in this document are libfyaml's
+own conventions, not requirements of the YAML standard.
+
+## Design goal
+
+The original intent of comment support in libfyaml was simply "keep comments
+around — they are useful". The current direction extends this toward
+**round-trip fidelity**: after a parse → emit cycle the output should be
+recognisable to the original author. Comments should appear at approximately
+the same position relative to the content they annotate, and they should
+survive operations such as key/sequence sorting.
+
+This is a best-effort goal. Highly unusual comment placements (e.g. a comment
+between a mapping key and its value indicator on the same line) may not
+round-trip perfectly.
+
+## Placement model
+
+Every comment is stored relative to a specific token and assigned one of three
+canonical placements:
+
+| Placement | Meaning |
+|-----------|---------|
+| `fycp_top` | Comment on the line(s) immediately preceding the token |
+| `fycp_right` | Comment on the same line as the token, after its content |
+| `fycp_bottom` | Comment on the line(s) immediately following a block that the token closes |
+
+These placements are stored and emitted independently. A token may carry
+comments at more than one placement simultaneously (e.g. both a top and a
+right comment).
+
+The emitter reconstructs the original column from an `indent_delta` stored at
+parse time. `indent_delta` is the distance between the comment's column and the
+indent level of the block it belongs to. This decouples emission from the order
+in which nodes are output, so that sort operations do not corrupt indentation.
+
+## Parser comment buffer invariants
+
+The parser holds at most two unattached comment atoms at any time, in fields
+`last_comment` and `override_comment`:
+
+- **`last_comment`** — the most recently scanned comment that has not yet been
+  attached to a token.
+- **`override_comment`** — a previously buffered comment that was displaced
+  from `last_comment` when a second comment was scanned before the first was
+  consumed. It is typically an older, more deeply nested comment.
+
+Invariant: when `override_comment` is set, `last_comment` is also set.
+
+Comments are consumed by `fy_attach_comments_if_any()`, which attaches them to
+the next token that is produced. At most one comment ends up at `fycp_top` and
+at most one at `fycp_right` per call; `override_comment` is always checked
+(and consumed) before `last_comment`.
+
+## Document-level comment rule
+
+A comment separated from the first content token of a document by **at least
+one blank line** is considered a document-level comment. It belongs to the
+document as a whole, not to the first content token.
+
+This is implemented as a promotion: the comment is moved from `last_comment`
+into `override_comment` so that it is attached to the synthetic
+`DOCUMENT_START` token rather than the first scalar/mapping/sequence token.
+
+The blank-line threshold (≥ 2 line difference between the comment's end line
+and the token's start line) is a heuristic. The YAML spec does not define the
+concept of a document-level comment.
+
+## Block scalar rule
+
+For block scalars (`|` literal, `>` folded), the scanner advances past the
+final content linebreak before the token's `end_mark` is recorded. This means
+`end_mark.line` is one line beyond the actual content.
+
+When testing whether a comment is on the same line as a token (and therefore
+a right-hand comment rather than a top comment for the *next* token), block
+scalars must use `start_mark.line` — the line of the `|` or `>` indicator —
+rather than `end_mark.line`. Inline comments on block scalars can only appear
+on the indicator line itself.
+
+## Block-end attribution rule
+
+When a block (mapping or sequence) is closed by `fy_parse_unroll_indent()`,
+any buffered comment that is:
+
+- more deeply indented than the target indent level, **and**
+- at least as indented as the block being closed
+
+is considered to belong to that block rather than to the next token at the
+parent level. It is attached as a `fycp_bottom` comment on the `BLOCK_END`
+token.
+
+`override_comment` is checked first (it is the older, typically deeper
+comment). `last_comment` is checked second. Comments that do not meet the
+column threshold are left in the buffer to be attached to the next token.
+
+## Sort-stability contract
+
+A `fycp_top` comment must travel with the node it annotates through sort
+operations (`fy_node_mapping_sort`, `fy_node_sequence_sort`). The token that
+carries the comment is therefore chosen to match what the sort moves:
+
+- **Standalone mapping key**: the `fycp_top` comment is left on the key scalar
+  token. `fy_node_mapping_sort` moves key tokens, so the comment follows.
+- **Sequence item that begins with a mapping**: the `fycp_top` comment is moved
+  from the key scalar to the `BLOCK_MAPPING_START` token.
+  `fy_node_sequence_sort` moves sequence items (whose representative token is
+  `BLOCK_MAPPING_START`), so the comment follows.
+
+The distinction between these two cases is signalled by the
+`pending_seq_item_key` flag in the parser state, which is set when a block
+sequence entry (`-`) is processed and cleared once the implicit mapping's value
+indicator (`:`) has been seen.
+
+## Emitter contract
+
+The emitter reads `indent_delta` from each comment atom and reconstructs the
+comment's column as `block_indent + indent_delta`. This means:
+
+1. `indent_delta` must be computed at the time the comment is attached, using
+   the indent level of the block the comment belongs to — not the parent.
+2. The emitter must pass the correct `old_indent` (the block's own indent) when
+   emitting `fycp_bottom` comments, so the column reconstruction is consistent
+   with what was stored.
+
+Violating this contract causes comments to shift left or right after a sort or
+any other operation that changes the order of emitted nodes.

--- a/python-libfyaml/tests/core/test_markers_comments.py
+++ b/python-libfyaml/tests/core/test_markers_comments.py
@@ -99,9 +99,10 @@ class TestComments:
         assert doc.get_comment() is None
 
     def test_header_comment(self):
-        """Header comments should be attached to following node."""
+        """Header comments attach to the first key, not the mapping root."""
         doc = fy.loads('# header\nfoo: bar\n', keep_comments=True)
-        comment = doc.get_comment()
+        first_key = next(iter(doc.keys()))
+        comment = first_key.get_comment()
         assert comment is not None
         assert 'header' in comment
 
@@ -118,9 +119,10 @@ class TestComments:
         assert doc['baz'].get_comment() is None
 
     def test_comment_is_string(self):
-        """Comments should be returned as strings."""
+        """Comments on the first key are returned as strings."""
         doc = fy.loads('# my comment\nfoo: bar\n', keep_comments=True)
-        comment = doc.get_comment()
+        first_key = next(iter(doc.keys()))
+        comment = first_key.get_comment()
         assert isinstance(comment, str)
 
     def test_comments_with_markers(self):
@@ -132,5 +134,33 @@ class TestComments:
         comment = doc['foo'].get_comment()
         assert marker is not None
         assert 'note' in comment
+
+    def test_doc_leading_comment_explicit(self):
+        """A comment before '---' is a doc-level comment accessible via doc.get_comment()."""
+        doc = fy.loads('# leading\n---\nfoo: bar\n', keep_comments=True)
+        comment = doc.get_comment()
+        assert comment is not None
+        assert 'leading' in comment
+
+    def test_doc_leading_comment_blank_separated(self):
+        """A comment separated from implicit-doc content by a blank line is doc-level."""
+        doc = fy.loads('# header\n\nfoo: bar\n', keep_comments=True)
+        comment = doc.get_comment()
+        assert comment is not None
+        assert 'header' in comment
+
+    def test_doc_trailing_comment(self):
+        """A trailing comment after all mapping content is accessible via doc.get_comment()."""
+        doc = fy.loads('foo: bar\n# trailing\n', keep_comments=True)
+        comment = doc.get_comment()
+        assert comment is not None
+        assert 'trailing' in comment
+
+    def test_inline_comment_not_doc_comment(self):
+        """A comment on the same line as content (no blank line) attaches to the key, not doc."""
+        doc = fy.loads('# header\nfoo: bar\n', keep_comments=True)
+        assert doc.get_comment() is None
+        first_key = next(iter(doc.keys()))
+        assert first_key.get_comment() is not None
 
 

--- a/src/lib/fy-emit.c
+++ b/src/lib/fy-emit.c
@@ -748,6 +748,7 @@ void fy_emit_comment_prolog(struct fy_emitter *emit,
 			if (comment_indent < 0)
 				comment_indent = 0;
 		}
+
 		fy_emit_write_indent(emit, comment_indent);
 		emit->flags |= FYEF_WHITESPACE;
 	}
@@ -756,13 +757,26 @@ void fy_emit_comment_prolog(struct fy_emitter *emit,
 void fy_emit_comment_epilog(struct fy_emitter *emit,
 			    int flags FY_UNUSED,
 		            int indent,
-			    enum fy_comment_placement placement)
+			    enum fy_comment_placement placement,
+			    struct fy_token *fyt,
+			    struct fy_atom *handle)
 {
 	emit->flags &= ~FYEF_INDENTATION;
 
-	if (placement == fycp_top || placement == fycp_bottom) {
+	if (placement == fycp_top) {
 		fy_emit_write_indent(emit, indent);
 		emit->flags |= FYEF_WHITESPACE;
+
+		/* Preserve blank lines between comment end and owning token start.
+		 * A blank line (two consecutive newlines) is semantically significant
+		 * in YAML and must survive a parse→emit round-trip. */
+		if (fyt && handle) {
+			int token_line = fy_token_start_line(fyt);
+			int comment_line = (int)handle->end_mark.line;
+			int extra = token_line - comment_line - 1;
+			while (extra-- > 0)
+				fy_emit_putc_simple(emit, fyewt_linebreak, '\n');
+		}
 	}
 }
 
@@ -770,11 +784,13 @@ void fy_emit_comment(struct fy_emitter *emit, int flags, int indent,
 		     enum fy_comment_placement placement,
 		     const char *text, size_t len,
 		     int indent_delta, enum fy_lb_mode lb_mode,
-		     bool needs_hash)
+		     bool needs_hash,
+		     struct fy_token *fyt,
+		     struct fy_atom *handle)
 {
 	fy_emit_comment_prolog(emit, flags, indent, indent_delta, placement);
 	fy_emit_write_comment(emit, flags, indent, text, len, lb_mode, needs_hash);
-	fy_emit_comment_epilog(emit, flags, indent, placement);
+	fy_emit_comment_epilog(emit, flags, indent, placement, fyt, handle);
 }
 
 void fy_emit_token_comment(struct fy_emitter *emit, struct fy_token *fyt, int flags, int indent,
@@ -809,7 +825,8 @@ void fy_emit_token_comment(struct fy_emitter *emit, struct fy_token *fyt, int fl
 	}
 
 	fy_emit_comment(emit, flags, indent, placement, t, len,
-			handle->indent_delta, fy_atom_lb_mode(handle), false);
+			handle->indent_delta, fy_atom_lb_mode(handle), false,
+			fyt, handle);
 
 	if (alloc)
 		free(alloc);
@@ -2414,10 +2431,10 @@ static void fy_emit_token_sequence_epilog(struct fy_emitter *emit, struct fy_emi
 	fy_emit_sequence_epilog(emit, sc);
 
 	/* emit trailing comment attached to the block-end token;
-	 * use old_indent (parent scope) so the trailing indent
-	 * doesn't produce an extra blank line */
-	if (fy_emit_token_has_comment(emit, fyt, fycp_top))
-		fy_emit_token_comment(emit, fyt, sc->flags, sc->old_indent, fycp_top);
+	 * use fycp_bottom with sc->indent (current block scope) so the
+	 * column is correct even after item reordering */
+	if (fy_emit_token_has_comment(emit, fyt, fycp_bottom))
+		fy_emit_token_comment(emit, fyt, sc->flags, sc->indent, fycp_bottom);
 
 	/* emit right-comment attached to the closing bracket token */
 	if (fy_emit_token_has_comment(emit, fyt, fycp_right))
@@ -2586,10 +2603,10 @@ static void fy_emit_token_mapping_epilog(struct fy_emitter *emit, struct fy_emit
 	fy_emit_mapping_epilog(emit, sc);
 
 	/* emit trailing comment attached to the block-end token;
-	 * use old_indent (parent scope) so the trailing indent
-	 * doesn't produce an extra blank line */
-	if (fy_emit_token_has_comment(emit, fyt, fycp_top))
-		fy_emit_token_comment(emit, fyt, sc->flags, sc->old_indent, fycp_top);
+	 * use fycp_bottom with sc->indent (current block scope) so the
+	 * column is correct even after item reordering */
+	if (fy_emit_token_has_comment(emit, fyt, fycp_bottom))
+		fy_emit_token_comment(emit, fyt, sc->flags, sc->indent, fycp_bottom);
 
 	/* emit right-comment attached to the closing brace token */
 	if (fy_emit_token_has_comment(emit, fyt, fycp_right))
@@ -5170,7 +5187,7 @@ void fy_emit_generic_comment(struct fy_emitter *emit, fy_generic v, int flags, i
 
 	szstr = fy_cast(vcomm, fy_szstr_empty);
 	fy_emit_comment(emit, flags, indent, placement,
-			szstr.data, szstr.size, 0, fylb_cr_nl, true);
+			szstr.data, szstr.size, 0, fylb_cr_nl, true, NULL, NULL);
 }
 
 int fy_emit_generic_scalar_prolog(struct fy_emitter *emit, fy_generic v, int flags, int indent)

--- a/src/lib/fy-parse.c
+++ b/src/lib/fy-parse.c
@@ -1049,6 +1049,15 @@ int fy_scan_comment(struct fy_parser *fyp, struct fy_atom *handle, bool single_l
 	return 0;
 }
 
+/* fy_comment_atoms_seperated_by_ws - test whether two comment atoms are
+ * adjacent in the input with only whitespace/linebreaks between them.
+ *
+ * Returns true when atoms a and b (in either order) are on the same input
+ * and the region between a.end_mark and b.start_mark contains nothing but
+ * whitespace or linebreak characters.  This is used to decide whether two
+ * separately-buffered comment atoms form a single logical comment block that
+ * can be merged into one span (by extending the earlier atom's end_mark to
+ * cover the later one). */
 bool
 fy_comment_atoms_seperated_by_ws(struct fy_parser *fyp FY_UNUSED,
 				 struct fy_atom *a,
@@ -1090,6 +1099,88 @@ fy_comment_atoms_seperated_by_ws(struct fy_parser *fyp FY_UNUSED,
 	return ws_or_lb;
 }
 
+/* fy_consolidate_pending_comments - fold override_comment back into last_comment.
+ *
+ * Structural tokens (BLOCK_SEQUENCE_START, BLOCK_MAPPING_START, …) must not
+ * consume buffered comments — those belong on the first content token and will
+ * be picked up by fy_attach_comments_if_any().  But by the time a structural
+ * token is emitted, a second comment may have displaced the first one into
+ * override_comment.  This function merges them back into a single last_comment
+ * so nothing is lost when fy_attach_comments_if_any() runs next.
+ *
+ * If the two atoms are adjacent (only whitespace between them) they form one
+ * logical block: extend override_comment's span to cover both and release the
+ * separate last_comment input reference.  Otherwise drop last_comment —
+ * override_comment is the outer, structurally significant comment and wins.
+ * Either way the result lands in last_comment, ready for the next attach. */
+static void
+fy_consolidate_pending_comments(struct fy_parser *fyp)
+{
+	if (!fy_atom_is_set(&fyp->override_comment))
+		return;
+
+	if (fy_atom_is_set(&fyp->last_comment) &&
+	    fy_comment_atoms_seperated_by_ws(fyp, &fyp->override_comment, &fyp->last_comment)) {
+		fyp->override_comment.end_mark = fyp->last_comment.end_mark;
+		fy_input_unref(fyp->last_comment.fyi);
+	}
+	fy_atom_reset(&fyp->last_comment);
+	fyp->last_comment = fyp->override_comment;
+	fy_atom_reset(&fyp->override_comment);
+}
+
+/* fy_steal_comment_bottom - move a comment atom onto a token as fycp_bottom.
+ *
+ * Takes ownership of *src (resetting it on success) and stores the comment on
+ * fyt at placement fycp_bottom with an indent_delta computed from ref_indent,
+ * so the emitter can reconstruct the original column as
+ * sc->indent + indent_delta regardless of any subsequent node reordering.
+ * Does nothing if fy_token_comment_handle() returns NULL. */
+static void
+fy_steal_comment_bottom(struct fy_parser *fyp FY_UNUSED, struct fy_token *fyt,
+			struct fy_atom *src, int ref_indent)
+{
+	struct fy_atom *handle;
+
+	handle = fy_token_comment_handle(fyt, fycp_bottom, true);
+	if (!handle)
+		return;
+
+	fy_input_unref(handle->fyi);
+	fy_atom_reset(handle);
+	*handle = *src;
+	if (ref_indent < 0)
+		ref_indent = 0;
+	fy_atom_set_indent_delta(handle, (int)handle->start_mark.column - ref_indent);
+	fy_atom_reset(src);
+}
+
+/* fy_steal_block_end_comments - attach any buffered comments that belong to a
+ * closing block onto its BLOCK_END token (fycp_bottom placement).
+ *
+ * A comment belongs to the block being closed when its column is strictly
+ * greater than the target indent (column) AND at least as deep as the block's
+ * own indent (current_indent).  override_comment is checked first because it
+ * is the older, typically more deeply nested comment.
+ * See doc/COMMENT-HANDLING.md - "Block-end attribution rule" */
+static void
+fy_steal_block_end_comments(struct fy_parser *fyp, struct fy_token *fyt,
+			    int column, int current_indent)
+{
+	if (!(fyp->cfg.flags & FYPCF_PARSE_COMMENTS))
+		return;
+
+	if (fy_atom_is_set(&fyp->override_comment) &&
+			(int)fyp->override_comment.start_mark.column > column &&
+			(int)fyp->override_comment.start_mark.column >= current_indent)
+		fy_steal_comment_bottom(fyp, fyt, &fyp->override_comment, current_indent);
+
+	if (fy_atom_is_set(&fyp->last_comment) &&
+			(int)fyp->last_comment.start_mark.column > column &&
+			(int)fyp->last_comment.start_mark.column >= current_indent)
+		fy_steal_comment_bottom(fyp, fyt, &fyp->last_comment, current_indent);
+}
+
 /* -1 error, 0, no comment attached, 1 comment attached */
 int fy_attach_comments_if_any(struct fy_parser *fyp, struct fy_token *fyt)
 {
@@ -1126,6 +1217,25 @@ int fy_attach_comments_if_any(struct fy_parser *fyp, struct fy_token *fyt)
 	/* if a last comment exists and is valid */
 	if (fy_atom_is_set(&fyp->last_comment)) {
 
+		/* Detect document-level leading comment for implicit documents.
+		 * When we're at the implicit doc start and the comment is separated
+		 * from the first content token by a blank line, promote it to
+		 * override_comment so it gets attached to the DOCUMENT_START token
+		 * instead of the first content token.
+		 * See doc/COMMENT-HANDLING.md - "Document-level comment rule" */
+		if (fyt->type != FYTT_DOCUMENT_START &&
+				fyp->state == FYPS_IMPLICIT_DOCUMENT_START &&
+				!fy_atom_is_set(&fyp->override_comment)) {
+			int cline = (int)fyp->last_comment.end_mark.line;
+			int tline = (int)fyt->handle.start_mark.line;
+			if (tline - cline >= 2) {
+				fy_input_unref(fyp->override_comment.fyi);
+				fyp->override_comment = fyp->last_comment;
+				fy_atom_reset(&fyp->last_comment);
+				return count;
+			}
+		}
+
 		handle = fy_token_comment_handle(fyt, count == 0 ? fycp_top : fycp_right, true);
 		fyp_error_check(fyp, handle, err_out,
 				"fy_token_comment_handle() top failed\n");
@@ -1137,7 +1247,6 @@ int fy_attach_comments_if_any(struct fy_parser *fyp, struct fy_token *fyt)
 		ref_indent = fyp->indent > 0 ? fyp->indent : 0;
 		fy_atom_set_indent_delta(handle, (int)handle->start_mark.column - ref_indent);
 		count++;
-
 		fy_atom_reset(&fyp->last_comment);
 	}
 
@@ -1152,9 +1261,19 @@ int fy_attach_comments_if_any(struct fy_parser *fyp, struct fy_token *fyt)
 
 	fy_get_mark(fyp, &fym);
 
-	/* only the one that in the same line */
-	if (fym.line != fyt->handle.end_mark.line)
-		return 0;
+	/* only the one that in the same line;
+	 * for block scalars end_mark is past the content (scanner advanced
+	 * past the final linebreak), so use start_mark.line (the indicator
+	 * line) instead - inline comments on block scalars can only appear
+	 * on the same line as | or >
+	 * See doc/COMMENT-HANDLING.md - "Block scalar rule" */
+	{
+		int ref_line = fy_atom_style_is_block(fyt->handle.style)
+				? fyt->handle.start_mark.line
+				: fyt->handle.end_mark.line;
+		if (fym.line != ref_line)
+			return 0;
+	}
 
 	/* it's a right comment only if it's on the same line */
 	handle = fy_token_comment_handle(fyt, fycp_right, true);
@@ -1618,29 +1737,18 @@ int fy_parse_unroll_indent(struct fy_parser *fyp, int column)
 		fyp_error_check(fyp, fyt, err_out,
 				"fy_token_queue_simple() failed");
 
-		rc = fy_pop_indent(fyp);
-		fyp_error_check(fyp, !rc, err_out,
-				"fy_pop_indent() failed");
+		/* save indent level before popping so comment delta is relative
+		 * to the block being closed, not its parent */
+		{
+			int current_indent = fyp->indent;
 
-		/* attach pending comment to this block-end token;
-		 * compute indent_delta relative to the parent indent
-		 * (after fy_pop_indent) so the emitter can pass old_indent
-		 * and get both correct comment column and trailing indent */
-		if ((fyp->cfg.flags & FYPCF_PARSE_COMMENTS) &&
-				fy_atom_is_set(&fyp->last_comment)) {
+			rc = fy_pop_indent(fyp);
+			fyp_error_check(fyp, !rc, err_out,
+					"fy_pop_indent() failed");
 
-			struct fy_atom *handle;
-			int ref_indent;
-
-			handle = fy_token_comment_handle(fyt, fycp_top, true);
-			if (handle) {
-				fy_input_unref(handle->fyi);
-				fy_atom_reset(handle);
-				*handle = fyp->last_comment;
-				ref_indent = fyp->indent > 0 ? fyp->indent : 0;
-				fy_atom_set_indent_delta(handle, (int)handle->start_mark.column - ref_indent);
-				fy_atom_reset(&fyp->last_comment);
-			}
+			/* Attach any comments that belong to this block to the
+			 * BLOCK_END token before the indent level is forgotten. */
+			fy_steal_block_end_comments(fyp, fyt, column, current_indent);
 		}
 
 		/* the ident line has now moved */
@@ -2755,7 +2863,6 @@ int fy_fetch_block_entry(struct fy_parser *fyp, int c)
 	struct fy_mark mark;
 	struct fy_simple_key *fysk;
 	struct fy_token *fyt;
-	struct fy_atom *handle;
 
 	fyp_error_check(fyp, c == '-', err_out,
 			"illegal block entry");
@@ -2784,8 +2891,6 @@ int fy_fetch_block_entry(struct fy_parser *fyp, int c)
 
 	if (fyp_block_mode(fyp) && fyp->indent < fyp_column(fyp)) {
 
-		int old_indent = fyp->indent;	/* save before push for comment delta */
-
 		/* push the new indent level */
 		rc = fy_push_indent(fyp, fyp_column(fyp), false, fyp_line(fyp));
 		fyp_error_check(fyp, !rc, err_out_rc,
@@ -2795,36 +2900,12 @@ int fy_fetch_block_entry(struct fy_parser *fyp, int c)
 		fyp_error_check(fyp, fyt, err_out,
 				"fy_token_queue_simple_internal() failed");
 
-		/* if a last comment exists and is valid */
-		if ((fyp->cfg.flags & FYPCF_PARSE_COMMENTS) &&
-				(fy_atom_is_set(&fyp->override_comment) || fy_atom_is_set(&fyp->last_comment))) {
-			int ref_indent;
-
-			handle = fy_token_comment_handle(fyt, fycp_top, true);
-			fyp_error_check(fyp, handle, err_out,
-				"fy_token_comment_handle() failed");
-			fy_input_unref(handle->fyi);
-			fy_atom_reset(handle);
-
-			if (fy_atom_is_set(&fyp->override_comment)) {
-				*handle = fyp->override_comment;
-				fy_atom_reset(&fyp->override_comment);
-			} else if (fy_atom_is_set(&fyp->last_comment)) {
-				*handle = fyp->last_comment;
-				fy_atom_reset(&fyp->last_comment);
-			}
-
-			/* compute indent_delta — same logic as fy_attach_comments_if_any()
-			 * but using old_indent (before fy_push_indent) as reference, since
-			 * the emitter will use the pre-increase mapping indent as base */
-			ref_indent = old_indent > 0 ? old_indent : 0;
-			fy_atom_set_indent_delta(handle, (int)handle->start_mark.column - ref_indent);
-		}
+		/* Do NOT attach buffered comments to BLOCK_SEQUENCE_START here —
+		 * they belong on the first item token and will be picked up by
+		 * fy_attach_comments_if_any() when that token is produced. */
+		if (fyp->cfg.flags & FYPCF_PARSE_COMMENTS)
+			fy_consolidate_pending_comments(fyp);
 	}
-
-	/* always reset the override comment */
-	fy_input_unref(fyp->override_comment.fyi);
-	fy_atom_reset(&fyp->override_comment);
 
 	if (c == '-' && fyp->flow_level) {
 		/* this is an error, but we let the parser catch it */
@@ -2860,6 +2941,12 @@ int fy_fetch_block_entry(struct fy_parser *fyp, int c)
 	fyt = fy_token_queue_simple(fyp, &fyp->queued_tokens, FYTT_BLOCK_ENTRY, 1);
 	fyp_error_check(fyp, fyt, err_out,
 			"fy_token_queue_simple() failed");
+
+	/* Signal that the next implicit-mapping key (if any) is a sequence item's first key.
+	 * fy_fetch_value() uses this to move the key's fycp_top comment to BLOCK_MAPPING_START
+	 * so the emitter's sequence_item_prolog can find it. */
+	fyp->pending_seq_item_key = true;
+	fyp_scan_debug(fyp, "pending_seq_item_key -> true");
 
 	rc = fy_ws_indentation_check(fyp, NULL, NULL);
 	fyp_error_check(fyp, !rc, err_out_rc,
@@ -2911,25 +2998,11 @@ int fy_fetch_key(struct fy_parser *fyp, int c)
 		fyp_error_check(fyp, fyt, err_out,
 				"fy_token_queue_simple_internal() failed");
 
-		/* if a last comment exists and is valid */
-		if ((fyp->cfg.flags & FYPCF_PARSE_COMMENTS) &&
-				(fy_atom_is_set(&fyp->override_comment) || fy_atom_is_set(&fyp->last_comment))) {
-
-			handle = fy_token_comment_handle(fyt, fycp_top, true);
-			fyp_error_check(fyp, handle, err_out,
-				"fy_token_comment_handle() failed");
-
-			fy_input_unref(handle->fyi);
-			fy_atom_reset(handle);
-
-			if (fy_atom_is_set(&fyp->override_comment)) {
-				*handle = fyp->override_comment;
-				fy_atom_reset(&fyp->override_comment);
-			} else if (fy_atom_is_set(&fyp->last_comment)) {
-				*handle = fyp->last_comment;
-				fy_atom_reset(&fyp->last_comment);
-			}
-		}
+		/* Do NOT attach buffered comments to BLOCK_MAPPING_START here —
+		 * they belong on the key scalar token and will be picked up by
+		 * fy_attach_comments_if_any() when the key is produced. */
+		if (fyp->cfg.flags & FYPCF_PARSE_COMMENTS)
+			fy_consolidate_pending_comments(fyp);
 	}
 
 	rc = fy_remove_simple_key(fyp, FYTT_KEY);
@@ -3130,45 +3203,50 @@ int fy_fetch_value(struct fy_parser *fyp, int c)
 		fyp_error_check(fyp, fyt, err_out,
 				"fy_token_queue_simple_internal() failed");
 
-		/* if a last comment exists and is valid */
 		if (fyp->cfg.flags & FYPCF_PARSE_COMMENTS) {
 
-			struct fy_atom *key_handle, *handle;
-
+			/* When the key is the first entry of a sequence item (flagged by
+			 * pending_seq_item_key set in fy_fetch_block_entry()), move the fycp_top
+			 * comment from the key scalar to BLOCK_MAPPING_START.  The emitter's
+			 * sequence_item_prolog looks for the comment on fyt_value = mapping_start,
+			 * and placing it there also ensures fy_node_sequence_sort carries the comment
+			 * with the item.  For standalone mappings, leave the comment on the key
+			 * scalar so it remains sort-stable under fy_node_mapping_sort.
+			 * See doc/COMMENT-HANDLING.md - "Sort-stability contract" */
 			if (fysk && fysk->token) {
-				key_handle = fy_token_comment_handle(fysk->token, fycp_top, true);
-				fyp_error_check(fyp, key_handle, err_out,
-					"fy_token_comment_handle() failed");
+				struct fy_atom *key_handle = fy_token_comment_handle(fysk->token, fycp_top, false);
+				if (key_handle && fy_atom_is_set(key_handle)) {
+					if (fyp->pending_seq_item_key) {
+						/* Sequence-item first key: move comment to BLOCK_MAPPING_START so
+						 * fy_node_sequence_sort carries it with the sequence item. */
+						struct fy_atom *bms_handle;
 
-				handle = fy_token_comment_handle(fyt, fycp_top, true);
-				fyp_error_check(fyp, handle, err_out,
-					"fy_token_comment_handle() failed");
+						bms_handle = fy_token_comment_handle(fyt, fycp_top, true);
+						fyp_error_check(fyp, bms_handle, err_out,
+								"fy_token_comment_handle() failed");
 
-				/* move the comment to the block mapping start */
-				fy_input_unref(handle->fyi);
-				fy_atom_reset(handle);
-				*handle = *key_handle;
-				fy_atom_reset(key_handle);
-			}
-
-			if (fy_atom_is_set(&fyp->override_comment) ||
-			    fy_atom_is_set(&fyp->last_comment)) {
-
-				handle = fy_token_comment_handle(fyt, fycp_top, true);
-				fyp_error_check(fyp, handle, err_out,
-					"fy_token_comment_handle() failed");
-
-				fy_input_unref(handle->fyi);
-				fy_atom_reset(handle);
-
-				if (fy_atom_is_set(&fyp->override_comment)) {
-					*handle = fyp->override_comment;
-					fy_atom_reset(&fyp->override_comment);
-				} else if (fy_atom_is_set(&fyp->last_comment)) {
-					*handle = fyp->last_comment;
-					fy_atom_reset(&fyp->last_comment);
+						fy_input_unref(bms_handle->fyi);
+						fy_atom_reset(bms_handle);
+						*bms_handle = *key_handle;
+						fy_atom_reset(key_handle);
+					} else {
+						/* Standalone mapping first key: leave comment on key scalar so
+						 * fy_node_mapping_sort carries it with the key.  Recompute
+						 * indent_delta relative to the new block indent (mark_insert.column)
+						 * so the emitter, which uses sc->indent = block_indent as the base,
+						 * reconstructs the correct column. */
+						int new_indent = (int)mark_insert.column;
+						fy_atom_set_indent_delta(key_handle,
+							(int)key_handle->start_mark.column - new_indent);
+					}
 				}
 			}
+			fyp->pending_seq_item_key = false;
+			fyp_scan_debug(fyp, "pending_seq_item_key -> false");
+
+			/* Consolidate buffered comments so fy_attach_comments_if_any()
+			 * can attach them to the VALUE token. */
+			fy_consolidate_pending_comments(fyp);
 		}
 
 		/* update with this mark */
@@ -3599,7 +3677,8 @@ int fy_fetch_block_scalar(struct fy_parser *fyp, bool is_literal, int c)
 	int lastc, rc, increment = 0, current_indent, new_indent, indent = 0, check_indent;
 	int breaks, breaks_length, presentation_breaks_length, first_break_length, max_indent, min_indent;
 	bool doc_start_end_detected, empty, empty_line, prev_empty_line, indented, prev_indented, first;
-	bool has_ws, has_lb, has_weird_nl, starts_with_ws, starts_with_lb, ends_with_ws, ends_with_lb, trailing_lb;
+	/* has_lb initialised to false; the loop may not execute on empty scalars */
+	bool has_ws, has_lb = false, has_weird_nl, starts_with_ws, starts_with_lb, ends_with_ws, ends_with_lb, trailing_lb;
 	bool pending_nl, ends_with_eof, starts_with_eof, content_is_eof;
 	struct fy_token *fyt;
 	size_t length, line_length, trailing_ws, trailing_breaks_length;
@@ -6396,6 +6475,29 @@ static struct fy_eventp *fy_parse_internal(struct fy_parser *fyp)
 			FYP_TOKEN_ERROR_CHECK(fyp, fyt, FYEM_PARSE,
 					!had_directives, err_out,
 					"missing required document start indicator after directives");
+
+			/* If a leading comment is separated from the first content token
+			 * by a blank line (>= 2 line difference), it is a document-level
+			 * comment.  Promote it to override_comment and attach it to the
+			 * synthetic DOCUMENT_START token so the emitter can reproduce it.
+			 *
+			 * Note: the comment will be in last_comment here even though
+			 * fy_attach_comments_if_any() promoted it to override_comment
+			 * during scalar scanning — the BLOCK_MAPPING_START code flows
+			 * override_comment back into last_comment so it reaches here. */
+			if ((fyp->cfg.flags & FYPCF_PARSE_COMMENTS) &&
+					fy_atom_is_set(&fyp->last_comment)) {
+				int comment_line = (int)fyp->last_comment.end_mark.line;
+				int token_line  = (int)handle.start_mark.line;
+				if (token_line - comment_line >= 2) {
+					fy_input_unref(fyp->override_comment.fyi);
+					fyp->override_comment = fyp->last_comment;
+					fy_atom_reset(&fyp->last_comment);
+					rc = fy_attach_comments_if_any(fyp, fye->document_start.document_start);
+					fyp_error_check(fyp, rc >= 0, err_out,
+							"fy_attach_comments_if_any() failed");
+				}
+			}
 
 			fy_parse_state_set(fyp, FYPS_BLOCK_NODE);
 

--- a/src/lib/fy-parse.h
+++ b/src/lib/fy-parse.h
@@ -198,6 +198,7 @@ struct fy_parser {
 			bool parse_flow_only : 1;	/* document is in flow form, and stop parsing at the end */
 			bool parse_block_only : 1;	/* document is in embedded block form, and stop parsing at the end */
 			bool colon_follows_colon : 1;	/* "foo"::bar -> "foo": :bar */
+			bool pending_seq_item_key : 1;	/* next implicit-mapping key is first in a sequence item */
 			bool had_directives : 1;	/* document had directives */
 			bool is_checkpoint : 1;		/* a parser checkpoint (not a real parser) */
 		};

--- a/test/libfyaml-test-emit-bugs.c
+++ b/test/libfyaml-test-emit-bugs.c
@@ -1508,6 +1508,102 @@ END_TEST
 
 #endif
 
+/* ═══════════════════════════════════════════════════════════════════
+ * Bug 22: Blank line between leading comment and document content
+ *         is dropped during parse→emit round-trip.
+ *
+ * A blank line separates a document-level comment from the content.
+ * The blank line must survive the round-trip.
+ * ═══════════════════════════════════════════════════════════════════ */
+
+START_TEST(emit_bug_doc_leading_comment_explicit_blank_line)
+{
+	/* # leading\n\n---\nfoo: bar\n — blank line before explicit --- preserved */
+	const char input[] = "# leading\n\n---\nfoo: bar\n";
+	char *buf = roundtrip_doc_comments(input);
+	ck_assert_ptr_ne(buf, NULL);
+	ck_assert_str_eq(buf, input);
+	free(buf);
+}
+END_TEST
+
+START_TEST(emit_bug_doc_leading_comment_implicit_blank_line)
+{
+	/* # leading\n\nfoo: bar\n — blank line before implicit doc content preserved */
+	const char input[] = "# leading\n\nfoo: bar\n";
+	char *buf = roundtrip_doc_comments(input);
+	ck_assert_ptr_ne(buf, NULL);
+	ck_assert_str_eq(buf, input);
+	free(buf);
+}
+END_TEST
+
+START_TEST(emit_bug_doc_leading_and_trailing_blank_line)
+{
+	/* # leading\n\nfoo: bar\n# trailing\n — blank line before content preserved */
+	const char input[] = "# leading\n\nfoo: bar\n# trailing\n";
+	char *buf = roundtrip_doc_comments(input);
+	ck_assert_ptr_ne(buf, NULL);
+	ck_assert_str_eq(buf, input);
+	free(buf);
+}
+END_TEST
+
+/* ═══════════════════════════════════════════════════════════════════
+ * Bug 23: Trailing comment after block scalar consumed as right-hand
+ *         comment and lost from the event stream.
+ *
+ * fy_attach_comments_if_any() compared the pending '#' position
+ * against end_mark.line.  After scanning a block scalar the parser
+ * has already advanced past the final linebreak, so end_mark.line
+ * lands on the line of any following comment.  The comment was
+ * therefore mis-classified as a right-hand (inline) comment on the
+ * scalar token and dropped from the output.
+ *
+ * Fix: use start_mark.line (the indicator line) for the same-line
+ * comparison when the token is a block scalar.
+ * ═══════════════════════════════════════════════════════════════════ */
+
+START_TEST(emit_bug_block_scalar_trailing_comment_not_consumed)
+{
+	/* trailing comment after a literal block scalar must survive
+	 * round-trip as a standalone comment, not be eaten as inline */
+	const char input[] = "run: |\n  command\n# trailing\n";
+	char *buf = roundtrip_doc_comments(input);
+	ck_assert_ptr_ne(buf, NULL);
+	ck_assert_str_eq(buf, input);
+	free(buf);
+}
+END_TEST
+
+START_TEST(emit_bug_block_scalar_trailing_comment_folded)
+{
+	/* same check for folded (>) block scalars */
+	const char input[] = "run: >\n  command\n# trailing\n";
+	char *buf = roundtrip_doc_comments(input);
+	ck_assert_ptr_ne(buf, NULL);
+	ck_assert_str_eq(buf, input);
+	free(buf);
+}
+END_TEST
+
+START_TEST(emit_bug_block_scalar_trailing_comment_in_sequence)
+{
+	/* trailing comment after a block scalar step in a sequence must
+	 * survive round-trip and not be promoted to document level */
+	const char input[] =
+		"steps:\n"
+		"- run: |\n"
+		"    command\n"
+		"  # trailing\n"
+		"- run: next\n";
+	char *buf = roundtrip_doc_comments(input);
+	ck_assert_ptr_ne(buf, NULL);
+	ck_assert_ptr_ne(strstr(buf, "# trailing"), NULL);
+	free(buf);
+}
+END_TEST
+
 /* ── registration ────────────────────────────────────────────────── */
 
 void libfyaml_case_emit_bugs(struct fy_check_suite *cs)
@@ -1641,4 +1737,14 @@ void libfyaml_case_emit_bugs(struct fy_check_suite *cs)
 	fy_check_testcase_add_test(ctc, emit_bug_invalid_utf8_generic_surrogate_d800);
 	fy_check_testcase_add_test(ctc, emit_bug_invalid_utf8_generic_surrogate_dfff);
 #endif
+
+	/* Bug 22: blank line between leading doc comment and content dropped */
+	fy_check_testcase_add_test(ctc, emit_bug_doc_leading_comment_explicit_blank_line);
+	fy_check_testcase_add_test(ctc, emit_bug_doc_leading_comment_implicit_blank_line);
+	fy_check_testcase_add_test(ctc, emit_bug_doc_leading_and_trailing_blank_line);
+
+	/* Bug 23: trailing comment after block scalar consumed as right-hand comment */
+	fy_check_testcase_add_test(ctc, emit_bug_block_scalar_trailing_comment_not_consumed);
+	fy_check_testcase_add_test(ctc, emit_bug_block_scalar_trailing_comment_folded);
+	fy_check_testcase_add_test(ctc, emit_bug_block_scalar_trailing_comment_in_sequence);
 }

--- a/test/libfyaml-test-emit.c
+++ b/test/libfyaml-test-emit.c
@@ -834,6 +834,329 @@ START_TEST(emit_subtree_comment_indent)
 }
 END_TEST
 
+static int scalar_seq_sort_cmp(struct fy_node *a, struct fy_node *b, void *arg)
+{
+	const char *sa = fy_node_get_scalar0(a);
+	const char *sb = fy_node_get_scalar0(b);
+	if (!sa) sa = "";
+	if (!sb) sb = "";
+	return strcmp(sa, sb);
+}
+
+START_TEST(emit_first_key_comment_follows_key_after_sort)
+{
+	struct fy_parse_cfg cfg = { .flags = FYPCF_PARSE_COMMENTS };
+	struct fy_document *fyd;
+	struct fy_node *root;
+	char *output;
+	const char *comment_pos, *z_pos, *a_pos;
+	int rc;
+
+	/* Comment before z (first key). After sorting, a comes first.
+	 * The comment must stay with z, not remain at the top. */
+	fyd = fy_document_build_from_string(&cfg,
+		"# above z\nz: 1\na: 2\n", FY_NT);
+	ck_assert_ptr_ne(fyd, NULL);
+
+	root = fy_document_root(fyd);
+	ck_assert_ptr_ne(root, NULL);
+
+	rc = fy_node_mapping_sort(root, NULL, NULL);
+	ck_assert_int_eq(rc, 0);
+
+	output = fy_emit_document_to_string(fyd, FYECF_OUTPUT_COMMENTS);
+	ck_assert_ptr_ne(output, NULL);
+
+	/* comment must appear in output */
+	comment_pos = strstr(output, "# above z");
+	ck_assert_ptr_ne(comment_pos, NULL);
+
+	/* a: must come before z: (sorted order) */
+	a_pos = strstr(output, "a:");
+	z_pos = strstr(output, "z:");
+	ck_assert_ptr_ne(a_pos, NULL);
+	ck_assert_ptr_ne(z_pos, NULL);
+	ck_assert(a_pos < z_pos);
+
+	/* comment must appear AFTER a: (i.e. with z, not at document top) */
+	ck_assert(comment_pos > a_pos);
+
+	free(output);
+	fy_document_destroy(fyd);
+}
+END_TEST
+
+START_TEST(emit_first_item_comment_follows_item_after_seq_sort)
+{
+	struct fy_parse_cfg cfg = { .flags = FYPCF_PARSE_COMMENTS };
+	struct fy_document *fyd;
+	struct fy_node *root, *seq;
+	char *output;
+	const char *comment_pos, *c_pos, *a_pos;
+	int rc;
+
+	fyd = fy_document_build_from_string(&cfg,
+		"items:\n  # above c\n  - c\n  - a\n", FY_NT);
+	ck_assert_ptr_ne(fyd, NULL);
+
+	root = fy_document_root(fyd);
+	ck_assert_ptr_ne(root, NULL);
+	seq = fy_node_by_path(root, "/items", FY_NT, FYNWF_DONT_FOLLOW);
+	ck_assert_ptr_ne(seq, NULL);
+
+	rc = fy_node_sequence_sort(seq, scalar_seq_sort_cmp, NULL);
+	ck_assert_int_eq(rc, 0);
+
+	output = fy_emit_document_to_string(fyd, FYECF_OUTPUT_COMMENTS);
+	ck_assert_ptr_ne(output, NULL);
+
+	comment_pos = strstr(output, "# above c");
+	ck_assert_ptr_ne(comment_pos, NULL);
+
+	a_pos = strstr(output, "- a");
+	c_pos = strstr(output, "- c");
+	ck_assert_ptr_ne(a_pos, NULL);
+	ck_assert_ptr_ne(c_pos, NULL);
+	ck_assert(a_pos < c_pos);
+
+	/* comment must appear after a (i.e. with c, not at top of sequence) */
+	ck_assert(comment_pos > a_pos);
+
+	free(output);
+	fy_document_destroy(fyd);
+}
+END_TEST
+
+static int mapping_seq_sort_by_name(struct fy_node *a, struct fy_node *b, void *arg)
+{
+	const char *na = fy_node_get_scalar0(fy_node_by_path(a, "/name", FY_NT, FYNWF_DONT_FOLLOW));
+	const char *nb = fy_node_get_scalar0(fy_node_by_path(b, "/name", FY_NT, FYNWF_DONT_FOLLOW));
+	if (!na) na = "";
+	if (!nb) nb = "";
+	return strcmp(na, nb);
+}
+
+START_TEST(emit_first_item_comment_follows_mapping_item_after_seq_sort)
+{
+	struct fy_parse_cfg cfg = { .flags = FYPCF_PARSE_COMMENTS };
+	struct fy_document *fyd;
+	struct fy_node *root, *seq;
+	char *output;
+	const char *comment_pos, *bar_pos, *foo_pos;
+	int rc;
+
+	/* Comment before the first sequence item (a mapping). After sort by name,
+	 * bar comes first; the comment must move with foo, not stay at the top. */
+	fyd = fy_document_build_from_string(&cfg,
+		"steps:\n"
+		"  # above foo\n"
+		"  - name: foo\n"
+		"  - name: bar\n", FY_NT);
+	ck_assert_ptr_ne(fyd, NULL);
+
+	root = fy_document_root(fyd);
+	ck_assert_ptr_ne(root, NULL);
+	seq = fy_node_by_path(root, "/steps", FY_NT, FYNWF_DONT_FOLLOW);
+	ck_assert_ptr_ne(seq, NULL);
+
+	rc = fy_node_sequence_sort(seq, mapping_seq_sort_by_name, NULL);
+	ck_assert_int_eq(rc, 0);
+
+	output = fy_emit_document_to_string(fyd, FYECF_OUTPUT_COMMENTS);
+	ck_assert_ptr_ne(output, NULL);
+
+	comment_pos = strstr(output, "# above foo");
+	bar_pos     = strstr(output, "name: bar");
+	foo_pos     = strstr(output, "name: foo");
+	ck_assert_ptr_ne(comment_pos, NULL);
+	ck_assert_ptr_ne(bar_pos, NULL);
+	ck_assert_ptr_ne(foo_pos, NULL);
+
+	/* bar must come before foo after sort */
+	ck_assert(bar_pos < foo_pos);
+	/* comment must travel with foo, not stay at top before bar */
+	ck_assert(comment_pos > bar_pos);
+
+	free(output);
+	fy_document_destroy(fyd);
+}
+END_TEST
+
+START_TEST(emit_multi_comment_blocks_before_first_key)
+{
+	struct fy_parse_cfg cfg = { .flags = FYPCF_PARSE_COMMENTS };
+	struct fy_document *fyd;
+	struct fy_node *root;
+	char *output;
+	const char *block_a, *block_b, *z_pos, *a_pos;
+	int rc;
+
+	fyd = fy_document_build_from_string(&cfg,
+		"# block A\n# block B\nz: 1\na: 2\n", FY_NT);
+	ck_assert_ptr_ne(fyd, NULL);
+
+	root = fy_document_root(fyd);
+	rc = fy_node_mapping_sort(root, NULL, NULL);
+	ck_assert_int_eq(rc, 0);
+
+	output = fy_emit_document_to_string(fyd, FYECF_OUTPUT_COMMENTS);
+	ck_assert_ptr_ne(output, NULL);
+
+	block_a = strstr(output, "# block A");
+	block_b = strstr(output, "# block B");
+	a_pos = strstr(output, "a:");
+	z_pos = strstr(output, "z:");
+	ck_assert_ptr_ne(block_a, NULL);
+	ck_assert_ptr_ne(block_b, NULL);
+	ck_assert_ptr_ne(a_pos, NULL);
+	ck_assert_ptr_ne(z_pos, NULL);
+
+	/* both comment blocks should follow z after sort (i.e. appear after a:) */
+	ck_assert(block_a > a_pos);
+	ck_assert(block_b > a_pos);
+	ck_assert(block_a < z_pos);
+	ck_assert(block_b < z_pos);
+
+	free(output);
+	fy_document_destroy(fyd);
+}
+END_TEST
+
+START_TEST(emit_first_key_comment_and_interstitial_with_sort)
+{
+	struct fy_parse_cfg cfg = { .flags = FYPCF_PARSE_COMMENTS };
+	struct fy_document *fyd;
+	struct fy_node *root;
+	char *output;
+	const char *before_z, *before_a, *z_pos, *a_pos;
+	int rc;
+
+	fyd = fy_document_build_from_string(&cfg,
+		"# before z\nz: 1\n# before a\na: 2\n", FY_NT);
+	ck_assert_ptr_ne(fyd, NULL);
+
+	root = fy_document_root(fyd);
+	rc = fy_node_mapping_sort(root, NULL, NULL);
+	ck_assert_int_eq(rc, 0);
+
+	output = fy_emit_document_to_string(fyd, FYECF_OUTPUT_COMMENTS);
+	ck_assert_ptr_ne(output, NULL);
+
+	before_z = strstr(output, "# before z");
+	before_a = strstr(output, "# before a");
+	a_pos = strstr(output, "a:");
+	z_pos = strstr(output, "z:");
+	ck_assert_ptr_ne(before_z, NULL);
+	ck_assert_ptr_ne(before_a, NULL);
+
+	/* after sort: # before a\na: 2\n# before z\nz: 1 */
+	ck_assert(before_a < a_pos);
+	ck_assert(before_z < z_pos);
+	ck_assert(before_z > a_pos);
+
+	free(output);
+	fy_document_destroy(fyd);
+}
+END_TEST
+
+START_TEST(emit_already_sorted_comments_stable)
+{
+	struct fy_parse_cfg cfg = { .flags = FYPCF_PARSE_COMMENTS };
+	struct fy_document *fyd;
+	struct fy_node *root;
+	char *output;
+	int rc;
+
+	fyd = fy_document_build_from_string(&cfg,
+		"# before a\na: 1\n# before b\nb: 2\n", FY_NT);
+	ck_assert_ptr_ne(fyd, NULL);
+
+	root = fy_document_root(fyd);
+	rc = fy_node_mapping_sort(root, NULL, NULL);
+	ck_assert_int_eq(rc, 0);
+
+	output = fy_emit_document_to_string(fyd, FYECF_OUTPUT_COMMENTS);
+	ck_assert_ptr_ne(output, NULL);
+
+	/* comments must still be present and in order */
+	const char *before_a = strstr(output, "# before a");
+	const char *before_b = strstr(output, "# before b");
+	const char *a_pos = strstr(output, "a:");
+	const char *b_pos = strstr(output, "b:");
+	ck_assert_ptr_ne(before_a, NULL);
+	ck_assert_ptr_ne(before_b, NULL);
+	ck_assert(before_a < a_pos);
+	ck_assert(before_b < b_pos);
+
+	free(output);
+	fy_document_destroy(fyd);
+}
+END_TEST
+
+START_TEST(emit_comment_idempotent_roundtrip)
+{
+	struct fy_parse_cfg cfg = { .flags = FYPCF_PARSE_COMMENTS };
+	struct fy_document *fyd;
+	char *output1, *output2;
+
+	/* parse → emit → parse → emit should be identical */
+	fyd = fy_document_build_from_string(&cfg,
+		"# before a\na: 1\n# before b\nb: 2\n", FY_NT);
+	ck_assert_ptr_ne(fyd, NULL);
+
+	output1 = fy_emit_document_to_string(fyd, FYECF_OUTPUT_COMMENTS);
+	ck_assert_ptr_ne(output1, NULL);
+	fy_document_destroy(fyd);
+
+	fyd = fy_document_build_from_string(&cfg, output1, FY_NT);
+	ck_assert_ptr_ne(fyd, NULL);
+
+	output2 = fy_emit_document_to_string(fyd, FYECF_OUTPUT_COMMENTS);
+	ck_assert_ptr_ne(output2, NULL);
+
+	ck_assert_str_eq(output1, output2);
+
+	free(output1);
+	free(output2);
+	fy_document_destroy(fyd);
+}
+END_TEST
+
+START_TEST(emit_nested_mapping_first_key_comment_sort)
+{
+	struct fy_parse_cfg cfg = { .flags = FYPCF_PARSE_COMMENTS };
+	struct fy_document *fyd;
+	struct fy_node *root, *inner;
+	char *output;
+	int rc;
+
+	fyd = fy_document_build_from_string(&cfg,
+		"outer:\n  # before z\n  z: 1\n  a: 2\n", FY_NT);
+	ck_assert_ptr_ne(fyd, NULL);
+
+	root = fy_document_root(fyd);
+	inner = fy_node_by_path(root, "/outer", FY_NT, FYNWF_DONT_FOLLOW);
+	ck_assert_ptr_ne(inner, NULL);
+
+	rc = fy_node_mapping_sort(inner, NULL, NULL);
+	ck_assert_int_eq(rc, 0);
+
+	output = fy_emit_document_to_string(fyd, FYECF_OUTPUT_COMMENTS);
+	ck_assert_ptr_ne(output, NULL);
+
+	/* comment should be with z, after a */
+	const char *comment = strstr(output, "# before z");
+	const char *a_pos = strstr(output, "a:");
+	const char *z_pos = strstr(output, "z:");
+	ck_assert_ptr_ne(comment, NULL);
+	ck_assert(comment > a_pos);
+	ck_assert(comment < z_pos);
+
+	free(output);
+	fy_document_destroy(fyd);
+}
+END_TEST
+
 START_TEST(emit_constructed_comment_indent)
 {
 	struct fy_document *fyd;
@@ -945,5 +1268,13 @@ void libfyaml_case_emit(struct fy_check_suite *cs)
 	fy_check_testcase_add_test(ctc, emit_streaming_multiline_flow_stays_multiline);
 	fy_check_testcase_add_test(ctc, emit_streaming_nested_flow_oneline);
 	fy_check_testcase_add_test(ctc, emit_subtree_comment_indent);
+	fy_check_testcase_add_test(ctc, emit_first_key_comment_follows_key_after_sort);
+	fy_check_testcase_add_test(ctc, emit_first_item_comment_follows_item_after_seq_sort);
+	fy_check_testcase_add_test(ctc, emit_first_item_comment_follows_mapping_item_after_seq_sort);
+	fy_check_testcase_add_test(ctc, emit_multi_comment_blocks_before_first_key);
+	fy_check_testcase_add_test(ctc, emit_first_key_comment_and_interstitial_with_sort);
+	fy_check_testcase_add_test(ctc, emit_already_sorted_comments_stable);
+	fy_check_testcase_add_test(ctc, emit_comment_idempotent_roundtrip);
+	fy_check_testcase_add_test(ctc, emit_nested_mapping_first_key_comment_sort);
 	fy_check_testcase_add_test(ctc, emit_constructed_comment_indent);
 }

--- a/test/libfyaml-test-parser.c
+++ b/test/libfyaml-test-parser.c
@@ -2660,28 +2660,28 @@ START_TEST(parser_comments_3)
 	fyn = fy_document_root(fyd);
 	ck_assert_ptr_ne(fyn, NULL);
 
-	/* top */
+	/* comment before first item is now on the item, not on the sequence */
 	comment = fy_node_get_comment(fyn, fycp_top);
-	ck_assert_ptr_ne(comment, NULL);
-	ck_assert_ptr_ne(strstr(comment, "top seq"), NULL);
-
-	/* all */
-	comment = fy_node_get_comments(fyn);
-	ck_assert_ptr_ne(comment, NULL);
-	ck_assert_ptr_ne(strstr(comment, "top seq"), NULL);
+	ck_assert_ptr_eq(comment, NULL);
 
 	/* get the first item of the sequence */
 	fyn = fy_node_by_path(fy_document_root(fyd), "/0", FY_NT, FYNWF_DONT_FOLLOW);
 	ck_assert_ptr_ne(fyn, NULL);
+
+	/* top — comment before first item now attached here */
+	comment = fy_node_get_comment(fyn, fycp_top);
+	ck_assert_ptr_ne(comment, NULL);
+	ck_assert_ptr_ne(strstr(comment, "top seq"), NULL);
 
 	/* right */
 	comment = fy_node_get_comment(fyn, fycp_right);
 	ck_assert_ptr_ne(comment, NULL);
 	ck_assert_ptr_ne(strstr(comment, "right item"), NULL);
 
-	/* all */
+	/* all — should include both top and right */
 	comment = fy_node_get_comments(fyn);
 	ck_assert_ptr_ne(comment, NULL);
+	ck_assert_ptr_ne(strstr(comment, "top seq"), NULL);
 	ck_assert_ptr_ne(strstr(comment, "right item"), NULL);
 
 	fy_document_destroy(fyd);


### PR DESCRIPTION
In #272 we fixed the issue of trailing comments being dropped by attaching them to the `BLOCK_MAPPING_START` / `BLOCK_SEQUENCE_START` structural tokens. But that's still not quite right because it now attaches pre-first-entry comments to the same structural token which isn't right.

For example 

```yaml
# above z
z: 1
a: 2
```

Becomes
```yaml
# above z       ← stays at top, "belongs to a" now
a: 1
z: 2
```

When it should travel with `a`. The fix is to change the attachment point to the first scalar key/item token instead, since that's actually what the node sorting stuff works with in any event.

While investigating the above it became clear two related cases were also broken:                                                                                                                                                
   
  - Blank-line-separated leading comments — a blank line between a leading comment and document content is the semantic signal it belongs to the document, not the first node. Previously the blank line was dropped and the comment was attached to the first key.                                                                                                                                                                                           
  - Trailing document comments — a comment after all mapping content wasn't accessible via doc.get_comment().  
  - Block scalar trailing comments consumed as inline comments - `fy_attach_comments_if_any()` used `end_mark.line` to detect whether a `#` token is on the same line as the preceding scalar. For block scalars (`|` / `>`) the scanner advances `end_mark` past the final line-break, placing it on the *next* line — meaning a standalone trailing comment was mistakenly identified as an inline comment on the scalar and consumed.
                                                                                                                                                                                                                     
All now round-trip correctly and are exposed through the Python API. Adjacent leading comments (no blank line) still attach to the first key as before. That said, happy to discuss the blank-line-as-document-comment semantic — it follows the spirit of YAML's intent but I don't believe it's explicitly standardised.     