### PR TITLE
Fix off-by-one in fy_accel_resize() prime table lookup

### DIFF
--- a/src/lib/fy-accel.c
+++ b/src/lib/fy-accel.c
@@ -103,7 +103,7 @@ int fy_accel_resize(struct fy_accel *xl, unsigned int min_buckets)
 	next_pow2 = 1;
 	exp = 0;
 	while (next_pow2 < min_buckets &&
-	       exp < sizeof(prime_lt_pow2)/sizeof(prime_lt_pow2[0])) {
+	       exp < sizeof(prime_lt_pow2)/sizeof(prime_lt_pow2[0]) - 1) {
 		next_pow2 <<= 1;
 		exp++;
 	}


### PR DESCRIPTION
The `while` loop in `fy_accel_resize()` increments `exp` inside the loop body, so when the guard checks `exp < ARRAY_SIZE(prime_lt_pow2)`, `exp` can reach the array size (20) after the final iteration. The subsequent `prime_lt_pow2[exp]` access is one past the end of the 20-element array.

This occurs when `min_buckets` exceeds 524,201 (the largest prime in the table), reachable via `fy_accel_setup()` with a large bucket count.

**Fix:** Use `ARRAY_SIZE - 1` as the loop bound so `exp` stays within the valid index range, capping at the last table entry. This is consistent with the bounds checking already present in `fy_accel_grow()`.

Found with cppcheck (`arrayIndexOutOfBoundsCond`). All 1,977 tests pass.