### PR TITLE
cmake: Do not look for libpthread on Android

### DIFF
--- a/cmake/libfyaml.pc.in
+++ b/cmake/libfyaml.pc.in
@@ -6,5 +6,5 @@ includedir=@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@
 Name: libfyaml
 Description: Fancy YAML 1.3 parser library
 Version: @PROJECT_VERSION@
-Libs: -L${libdir} -lfyaml -lpthread
+Libs: -L${libdir} -lfyaml @CMAKE_THREAD_LIBS_INIT@
 Cflags: -I${includedir}


### PR DESCRIPTION
This patch makes possible to build libfyaml on Android with vcpkg: https://github.com/microsoft/vcpkg/pull/51490