### PR TITLE
fy-doc: fix -Wdiscarded-qualifiers by declaring p as const char *

### DIFF
--- a/src/lib/fy-doc.c
+++ b/src/lib/fy-doc.c
@@ -4290,8 +4290,8 @@ fy_node_by_path_internal(struct fy_node *fyn,
 {
 	enum fy_node_walk_flags ptr_flags;
 	struct fy_node *fynt, *fyni;
-	const char *s, *e, *ss, *ee;
-	char *end_idx, *json_key, *t, *p, *uri_path;
+	const char *s, *e, *ss, *ee, *p;
+	char *end_idx, *json_key, *t, *uri_path;
 	char c;
 	char idx_buf[13];
 	size_t idx_buf_sz;


### PR DESCRIPTION
C23 memchr() returns const-qualified pointer when passed a const pointer target, so p must be const char * to match. Assigning a non-const char * from memchr() remains valid in older standards for backward compatibility.