### PR TITLE
configure.ac: fix for double-passing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,8 +105,9 @@ AC_PROG_LN_S
 
 AX_PTHREAD([], [AC_MSG_ERROR("Missing required pthread support")])
 
-# in some cases PTHREAD_LIBS is empty - force -lpthread */
-if test "x$PTHREAD_LIBS" = "x"; then
+# In some cases PTHREAD_LIBS is empty; force -lpthread only when PTHREAD_CFLAGS
+# also provides no pthread support (e.g. on Darwin, -pthread in CFLAGS suffices).
+if test "x$PTHREAD_LIBS" = "x" && test "x$PTHREAD_CFLAGS" = "x"; then
 	PTHREAD_LIBS="-lpthread"
 fi
 


### PR DESCRIPTION
Quirk of intention I found! 

Where the assumption of the code is that if there are no lib flags set, then just use the fallback of lpthread.

BUT! The way nixes libSystem passes to it (And likely other callers!!!) nothing because it's trying to communicate that it's _taking care of it_ using PTHREAD_CFLAGS. It leads to this weird situation where both are passed!