### PR TITLE
test: add C++ translation-unit compilation tests for libfyaml-atomics.h and add a fix to the build errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1629,6 +1629,64 @@ if(CAN_TEST)
 
 endif()
 
+# C++ compatibility tests
+# These executables are built as C++ translation units and verify that the
+# public libfyaml headers (in particular libfyaml-atomics.h) can be included
+# and used from C++ code — the usage pattern in projects such as MRPT.
+# They require only a C++ compiler and the shared fyaml target; no check/bash.
+include(CheckLanguage)
+check_language(CXX)
+if(CMAKE_CXX_COMPILER)
+    enable_language(CXX)
+
+    # Pick a C++ standard high enough for libfyaml-atomics.h to find a usable
+    # atomic backend on every supported compiler:
+    #
+    #   * GCC / Clang: any C++ standard (>= 17) works — they expose <stdatomic.h>
+    #     or fall back to GCC-extension macros that are accepted in C++.
+    #   * MSVC:        requires C++23 (/std:c++latest), since MSVC's
+    #                  <stdatomic.h> is a stub before C++23 (warning STL4038)
+    #                  and _Atomic is not provided as an extension keyword.
+    if(MSVC)
+        set(_FYAML_CPP_TEST_STANDARD 23)
+    else()
+        set(_FYAML_CPP_TEST_STANDARD 17)
+    endif()
+
+    # Test 1: libfyaml-atomics.h usable from a C++ TU
+    add_executable(libfyaml-test-cpp-atomics
+        test/libfyaml-test-cpp-atomics.cpp
+    )
+    set_target_properties(libfyaml-test-cpp-atomics PROPERTIES
+        CXX_STANDARD ${_FYAML_CPP_TEST_STANDARD}
+        CXX_STANDARD_REQUIRED ON
+    )
+    target_include_directories(libfyaml-test-cpp-atomics PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_link_libraries(libfyaml-test-cpp-atomics PRIVATE fyaml)
+    if(BUILD_TESTING)
+        add_test(NAME cpp-atomics COMMAND libfyaml-test-cpp-atomics)
+    endif()
+
+    # Test 2: libfyaml-core.h (and therefore the full public API) usable
+    # from a pure C++ translation unit — mirrors the MRPT yaml.cpp use-case.
+    add_executable(libfyaml-test-cpp-include-tu
+        test/libfyaml-test-cpp-include-tu.cpp
+    )
+    set_target_properties(libfyaml-test-cpp-include-tu PROPERTIES
+        CXX_STANDARD ${_FYAML_CPP_TEST_STANDARD}
+        CXX_STANDARD_REQUIRED ON
+    )
+    target_include_directories(libfyaml-test-cpp-include-tu PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_link_libraries(libfyaml-test-cpp-include-tu PRIVATE fyaml)
+    if(BUILD_TESTING)
+        add_test(NAME cpp-include-tu COMMAND libfyaml-test-cpp-include-tu)
+    endif()
+endif()
+
 # Documentation
 find_program(SPHINX_EXECUTABLE NAMES sphinx-build)
 find_program(LATEXMK_EXECUTABLE NAMES latexmk)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1285,7 +1285,11 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CheckClangBlocks.cmake)
 
 # Apply flags if available
 if (HAVE_CLANG_BLOCKS)
-    add_compile_options(-fblocks)
+    # Restrict the global -fblocks flag to C targets only: C++ targets inherit
+    # add_compile_options() entries but -fblocks is a Clang/Apple extension
+    # that GCC's C++ frontend rejects.  C targets also receive it via
+    # COMMON_C_FLAGS below, so there is no change in behaviour for them.
+    add_compile_options($<$<COMPILE_LANGUAGE:C>:-fblocks>)
     list(APPEND COMMON_C_FLAGS -fblocks)
 
     if (CLANG_BLOCKS_LIB)

--- a/include/libfyaml.h
+++ b/include/libfyaml.h
@@ -27,6 +27,13 @@
 #ifndef LIBFYAML_H
 #define LIBFYAML_H
 
+/* Pull in the portability/atomics shim BEFORE opening the umbrella's
+ * extern "C" block.  libfyaml-atomics.h may transitively #include
+ * <stdatomic.h> (in C++ mode on MSVC C++23 / Clang), whose contents are
+ * C++ templates and therefore cannot live inside extern "C".  The header
+ * is otherwise self-contained (its own extern "C" wrapping is internal). */
+#include <libfyaml/libfyaml-atomics.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -80,7 +87,7 @@ extern "C" {
 #include <libfyaml/libfyaml-blake3.h>
 #include <libfyaml/libfyaml-align.h>
 #include <libfyaml/libfyaml-endian.h>
-#include <libfyaml/libfyaml-atomics.h>
+/* libfyaml-atomics.h is included above, before extern "C", for C++ safety */
 #include <libfyaml/libfyaml-vlsize.h>
 
 #ifdef __cplusplus

--- a/include/libfyaml/libfyaml-atomics.h
+++ b/include/libfyaml/libfyaml-atomics.h
@@ -50,6 +50,13 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+/* MSVC's _mm_pause()/__yield() intrinsics used by fy_cpu_relax() require
+ * <intrin.h>; pull it in here so the inline definition compiles cleanly in
+ * any translation unit (including C++ TUs that don't otherwise include it). */
+#if defined(_MSC_VER)
+#include <intrin.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -60,22 +67,57 @@ extern "C" {
  * When defined, the standard ``atomic_*`` types and functions are in scope
  * and all ``fy_atomic_*`` macros delegate to them.
  *
- * This macro is defined if STDC version >= 201112L or
- * for GCC version >= 4.9
- * for clang version >= 3.6
+ * C mode  : STDC version >= 201112L, GCC >= 4.9, Clang >= 3.6, MSVC >= 1928
+ * C++ mode: Clang >= 3.6 (supports <stdatomic.h> and _Atomic as extensions),
+ *           MSVC >= 1938 + C++23 (_MSVC_LANG >= 202302L): MSVC's <stdatomic.h>
+ *           is a stub before C++23 (STL4038 warning) and _Atomic is not
+ *           provided as an extension keyword, so older MSVC C++ modes cannot
+ *           use it.  Build the test executables with /std:c++latest on MSVC.
+ *
+ *           GCC C++ intentionally excluded: it falls back to its own
+ *           ({ }/__typeof__) extension macros instead, which is sufficient
+ *           and avoids pulling <stdatomic.h> into C++ translation units on
+ *           libstdc++ where the interaction is less well-tested.
+ *           Clang must use <stdatomic.h> because libc++'s <atomic> declares
+ *           functions named atomic_load/atomic_store/... that collide with
+ *           the fallback macros when any C++ header transitively includes
+ *           <atomic> (e.g. <optional>, <string_view> on libc++).
  *
  * The check is required only for _really_ old compilers
  */
 #if !defined(__STDC__NO_ATOMICS__) && \
-	(defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) || \
-	(defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9))) || \
-	(defined(__clang__) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 6)))
+	((!defined(__cplusplus) && \
+	  ((defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L) || \
+	   (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 9))) || \
+	   (defined(__clang__) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 6))) || \
+	   (defined(_MSC_VER) && _MSC_VER >= 1928))) || \
+	 (defined(__cplusplus) && \
+	  ((defined(__clang__) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 6))) || \
+	   (defined(_MSC_VER) && _MSC_VER >= 1938 && \
+	    defined(_MSVC_LANG) && _MSVC_LANG >= 202302L))))
 #define FY_HAVE_STDATOMIC_H
 #endif
 
 /* Detect standard C11 atomics */
 #ifdef FY_HAVE_STDATOMIC_H
+/* <stdatomic.h> may contain templates (MSVC C++23) or other C++-incompatible
+ * constructs when included inside an extern "C" linkage scope.  Use
+ * ``extern "C++"`` to escape *any* depth of enclosing extern "C" blocks --
+ * not just the one this header opens at the top, but also any opened by an
+ * umbrella header that included us (e.g. libfyaml.h wraps all sub-headers in
+ * its own extern "C"). When the brace closes, the enclosing C-linkage scope
+ * is automatically restored.
+ *
+ * Function declarations inside <stdatomic.h> (e.g. atomic_thread_fence) get
+ * C++ linkage in this block, but they are overshadowed by macros in the same
+ * header on every supported compiler, so no symbol is ever referenced. */
+#ifdef __cplusplus
+extern "C++" {
+#endif
 #include <stdatomic.h>
+#ifdef __cplusplus
+} /* close extern "C++" */
+#endif
 /*
  * FY_HAVE_C11_ATOMICS - Defined when the ``_Atomic`` qualifier is usable.
  *
@@ -201,15 +243,16 @@ typedef bool atomic_flag;
 	} while(0)
 
 
+/* C11 atomic_flag_test_and_set returns the *old* value of the flag,
+ * unconditionally setting it to true.  The previous implementation had the
+ * return values inverted (returning true on a previously-clear flag), which
+ * caused fy_atomic_flag_test_and_set() to misreport state on every compiler
+ * that falls back to these macros (e.g. GCC in C++ mode). */
 #define atomic_flag_test_and_set(_ptr) \
 	({ \
 		volatile atomic_flag *__ptr = (_ptr); \
-		bool __ret; \
-		if (!*__ptr) { \
-			*__ptr = true; \
-			__ret = true; \
-		} else \
-			__ret = false; \
+		bool __ret = *__ptr; \
+		*__ptr = true; \
 		__ret; \
 	})
 

--- a/include/libfyaml/libfyaml-atomics.h
+++ b/include/libfyaml/libfyaml-atomics.h
@@ -154,6 +154,68 @@ extern "C++" {
  * therefore only safe in single-threaded contexts.
  */
 #define FY_HAVE_SAFE_ATOMIC_OPS
+#elif defined(_MSC_VER) && defined(__cplusplus)
+
+/* MSVC C++ fallback (C++17 and earlier, where <stdatomic.h> is unavailable).
+ * MSVC does not support GCC statement-expressions ({ }) or __typeof__, so we
+ * use decltype and immediately-invoked C++ lambdas for the fetch-and-modify
+ * operations.  These are plain (non-atomic) loads/stores; safe only in
+ * single-threaded contexts. */
+
+#undef FY_HAVE_SAFE_ATOMIC_OPS
+
+typedef bool atomic_flag;
+
+#define atomic_load(_ptr) \
+	(*(_ptr))
+
+#define atomic_store(_ptr, _val) \
+	do { \
+		*(_ptr) = (_val); \
+	} while(0)
+
+#define atomic_exchange(_ptr, _v) \
+	([&]() -> decltype(*(_ptr)) { decltype(*(_ptr)) __old = *(_ptr); *(_ptr) = (_v); return __old; }())
+
+#define atomic_compare_exchange_strong(_ptr, _exp, _des) \
+	([&]() -> bool { \
+		bool __res; \
+		if (*(_ptr) == *(_exp)) { *(_ptr) = (_des); __res = true; } \
+		else __res = false; \
+		return __res; \
+	}())
+
+#define atomic_compare_exchange_weak(_ptr, _exp, _des) \
+	atomic_compare_exchange_strong((_ptr), (_exp), (_des))
+
+#define atomic_fetch_add(_ptr, _v) \
+	([&]() -> decltype(*(_ptr)) { decltype(*(_ptr)) __old = *(_ptr); *(_ptr) += (_v); return __old; }())
+
+#define atomic_fetch_sub(_ptr, _v) \
+	([&]() -> decltype(*(_ptr)) { decltype(*(_ptr)) __old = *(_ptr); *(_ptr) -= (_v); return __old; }())
+
+#define atomic_fetch_or(_ptr, _v) \
+	([&]() -> decltype(*(_ptr)) { decltype(*(_ptr)) __old = *(_ptr); *(_ptr) |= (_v); return __old; }())
+
+#define atomic_fetch_xor(_ptr, _v) \
+	([&]() -> decltype(*(_ptr)) { decltype(*(_ptr)) __old = *(_ptr); *(_ptr) ^= (_v); return __old; }())
+
+#define atomic_fetch_and(_ptr, _v) \
+	([&]() -> decltype(*(_ptr)) { decltype(*(_ptr)) __old = *(_ptr); *(_ptr) &= (_v); return __old; }())
+
+#define atomic_flag_clear(_ptr) \
+	do { \
+		*(_ptr) = false; \
+	} while(0)
+
+#define atomic_flag_set(_ptr) \
+	do { \
+		*(_ptr) = true; \
+	} while(0)
+
+#define atomic_flag_test_and_set(_ptr) \
+	([&]() -> bool { volatile atomic_flag *__p = (_ptr); bool __ret = *__p; *__p = true; return __ret; }())
+
 #else
 
 #undef FY_HAVE_SAFE_ATOMIC_OPS

--- a/test/libfyaml-test-cpp-atomics.cpp
+++ b/test/libfyaml-test-cpp-atomics.cpp
@@ -1,0 +1,76 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * libfyaml-test-cpp-atomics.cpp - C++ compilation test for libfyaml-atomics.h
+ *
+ * Regression test for the <stdatomic.h> detection bug in libfyaml-atomics.h:
+ *
+ * Bug 1 (operator-precedence): The FY_HAVE_STDATOMIC_H detection condition
+ *   treats the leading !defined(__STDC__NO_ATOMICS__) as only guarding the
+ *   first OR clause, so GCC/Clang fire unconditionally in C++ mode — yet the
+ *   <stdatomic.h> include was inside extern "C", which breaks C++ compilers
+ *   whose <stdatomic.h> contains C++-incompatible constructs (e.g. templates
+ *   or _Atomic typedefs) at that linkage scope.
+ *
+ * Bug 2 (fallback macros): When FY_HAVE_STDATOMIC_H is not defined the header
+ *   falls back to macros using ({ }) GNU statement-expressions and __typeof__,
+ *   which are GCC extensions unavailable in strict C++ or MSVC.
+ *
+ * This file must compile cleanly as C++ with -std=c++17 (or later).
+ * It fails to compile against the unfixed libfyaml-atomics.h (v1.0.0-alpha6).
+ */
+
+#include <libfyaml/libfyaml-atomics.h>
+
+#include <cassert>
+#include <cstdint>
+
+static int test_atomic_int(void)
+{
+    /* Basic load / store round-trip. */
+    FY_ATOMIC(int) v = 0;
+    fy_atomic_store(&v, 7);
+    int got = fy_atomic_load(&v);
+    assert(got == 7);
+
+    /* fetch_add returns the old value. */
+    int old = fy_atomic_fetch_add(&v, 3);
+    assert(old == 7);
+    assert(fy_atomic_load(&v) == 10);
+
+    return 0;
+}
+
+static int test_atomic_flag(void)
+{
+    fy_atomic_flag flag = {};
+    fy_atomic_flag_clear(&flag);
+    /* test_and_set: first call must return false (flag was clear). */
+    bool was_set = fy_atomic_flag_test_and_set(&flag);
+    assert(!was_set);
+    /* second call must return true (flag was already set). */
+    was_set = fy_atomic_flag_test_and_set(&flag);
+    assert(was_set);
+    fy_atomic_flag_clear(&flag);
+    return 0;
+}
+
+static int test_drain_counter(void)
+{
+    FY_ATOMIC(uint64_t) ctr = 0;
+    fy_atomic_fetch_add(&ctr, 5);
+    uint64_t drained = fy_atomic_get_and_clear_counter(&ctr);
+    assert(drained == 5);
+    /* counter is not guaranteed to be exactly 0 (two-op drain), but must be
+     * no greater than the original value. */
+    assert(fy_atomic_load(&ctr) <= 5);
+    return 0;
+}
+
+int main(void)
+{
+    int rc = 0;
+    rc |= test_atomic_int();
+    rc |= test_atomic_flag();
+    rc |= test_drain_counter();
+    return rc;
+}

--- a/test/libfyaml-test-cpp-include-tu.cpp
+++ b/test/libfyaml-test-cpp-include-tu.cpp
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: MIT */
+/*
+ * libfyaml-test-cpp-include-tu.cpp - C++ TU inclusion test for libfyaml
+ *
+ * Regression test for building libfyaml from a C++ translation unit, which
+ * is the usage pattern in MRPT (yaml.cpp includes <libfyaml.h> directly).
+ *
+ * The unfixed libfyaml-atomics.h (v1.0.0-alpha6) fails to compile here
+ * because <stdatomic.h> is pulled in while still inside extern "C".  On
+ * compilers where <stdatomic.h> uses C++-incompatible constructs at that
+ * linkage scope (e.g. _Atomic typedefs on GCC with -std=c++17), this
+ * produces errors such as:
+ *
+ *   error: '_Atomic' was not declared in this scope
+ *   error: expected primary-expression before ')' token
+ *
+ * After the fix the same file compiles without modification.
+ *
+ * Include order note: on Clang/libc++, <stdatomic.h> defines atomic_load,
+ * atomic_store, atomic_is_lock_free etc. as function-like macros.  If any
+ * C++ STL header that transitively includes <atomic> is then compiled while
+ * those macros are active, libc++'s template function declarations get
+ * macro-expanded and cause parse errors.  Keep <libfyaml.h> before any
+ * such STL headers, or (safer) avoid STL headers that reach <atomic> in
+ * the same TU.  This test deliberately uses only <cstdio>/<cstring> to
+ * stay portable across all STL implementations.
+ *
+ * In addition to the compile check this test performs a minimal parse so
+ * that the binary can be run as part of the CTest suite.
+ */
+
+/* libfyaml.h pulls in libfyaml-atomics.h; if the latter is broken the
+ * compilation stops here with the errors described above. */
+#include <libfyaml.h>
+
+#include <cstdio>
+#include <cstring>
+
+int main(void)
+{
+    static const char yaml_src[] = "key: value\n";
+
+    struct fy_document *fyd =
+        fy_document_build_from_string(nullptr, yaml_src,
+                                      sizeof(yaml_src) - 1);
+    if (!fyd) {
+        std::fprintf(stderr, "fy_document_build_from_string failed\n");
+        return 1;
+    }
+
+    /* Look up the scalar at /key and verify its value. */
+    char buf[64] = {};
+    int rc = fy_document_scanf(fyd, "/key %63s", buf);
+    fy_document_destroy(fyd);
+
+    if (rc != 1) {
+        std::fprintf(stderr, "fy_document_scanf returned %d, expected 1\n", rc);
+        return 1;
+    }
+    if (std::strcmp(buf, "value") != 0) {
+        std::fprintf(stderr, "unexpected value: '%s'\n", buf);
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Two minimal C++ programs that reveal the <stdatomic.h> portability bug present in libfyaml-atomics.h at "master" + a fix to it. 

Please refer to the detailed explanation in the commit messages.
