### PR TITLE
lib: add picolibc compatibility for embedded builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -964,6 +964,7 @@ set(UTILHDRS
     src/util/fy-bit64.h
     src/util/fy-vlsize.h
     src/util/fy-win32.h
+    src/util/fy-picolibc.h
 )
 
 set(LIBSRCS

--- a/include/libfyaml/libfyaml-align.h
+++ b/include/libfyaml/libfyaml-align.h
@@ -141,8 +141,16 @@ static inline void *fy_align_alloc(size_t align, size_t size)
 
 	size = FY_ALIGN(align, size);
 #ifndef _WIN32
+#if defined(__PICOLIBC__)
+	/* picolibc has no posix_memalign; use C11 aligned_alloc (size is
+	 * already a multiple of align). Freed with plain free(). */
+	p = aligned_alloc(align, size);
+	if (!p)
+		return NULL;
+#else
 	if (posix_memalign(&p, align, size))
 		return NULL;
+#endif
 #else
 	p = _aligned_malloc(size, align);
 	if (!p)

--- a/include/libfyaml/libfyaml-endian.h
+++ b/include/libfyaml/libfyaml-endian.h
@@ -54,6 +54,11 @@ extern "C" {
 # define __LITTLE_ENDIAN 1234
 # define __BIG_ENDIAN    4321
 # define __BYTE_ORDER    __LITTLE_ENDIAN
+#elif defined(__PICOLIBC__)
+/* picolibc has no <endian.h>; use the compiler's built-in byte-order macros. */
+# define __LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
+# define __BIG_ENDIAN    __ORDER_BIG_ENDIAN__
+# define __BYTE_ORDER    __BYTE_ORDER__
 #else
 # error unsupported platform
 #endif

--- a/include/libfyaml/libfyaml-util.h
+++ b/include/libfyaml/libfyaml-util.h
@@ -68,6 +68,20 @@ struct iovec {
 	size_t iov_len;
 };
 #endif
+#elif defined(__PICOLIBC__)
+/* picolibc (the common Zephyr C library) has no <sys/uio.h>; provide iovec. */
+#include <unistd.h>
+#ifndef _FY_IOVEC_DEFINED
+#define _FY_IOVEC_DEFINED
+struct iovec {
+	void *iov_base;
+	size_t iov_len;
+};
+#endif
+/* picolibc does not define SSIZE_MAX; ssize_t has the width of size_t. */
+#ifndef SSIZE_MAX
+#define SSIZE_MAX ((ssize_t)(SIZE_MAX >> 1))
+#endif
 #else
 #include <sys/uio.h>
 #endif

--- a/samples/parse_string/CMakeLists.txt
+++ b/samples/parse_string/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(libfyaml_parse_string)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/parse_string/boards/nrf52840dk_nrf52840.conf
+++ b/samples/parse_string/boards/nrf52840dk_nrf52840.conf
@@ -1,0 +1,11 @@
+# nrf52840 (picolibc) needs Zephyr's POSIX layer to supply the I/O syscalls
+# (open/read/write/close/lseek/isatty/sysconf) that libfyaml's diag and
+# emitter reference. The library parses from memory; these are not used for
+# files, but the symbols must resolve at link time.
+CONFIG_POSIX_API=y
+
+# Heap for the document tree (malloc/free).
+CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=65536
+
+# The parser recurses; give main a comfortable stack.
+CONFIG_MAIN_STACK_SIZE=8192

--- a/samples/parse_string/prj.conf
+++ b/samples/parse_string/prj.conf
@@ -1,0 +1,5 @@
+CONFIG_LIBFYAML=y
+
+# libfyaml allocates with malloc/realloc/free.
+CONFIG_COMMON_LIBC_MALLOC=y
+CONFIG_COMMON_LIBC_MALLOC_ARENA_SIZE=131072

--- a/samples/parse_string/sample.yaml
+++ b/samples/parse_string/sample.yaml
@@ -1,0 +1,13 @@
+sample:
+  name: libfyaml-parse-string
+  description: Parse a YAML document from an in-memory buffer on Zephyr
+tests:
+  sample.lib.libfyaml.parse_string:
+    platforms:
+      - native_sim
+    tags: libfyaml yaml
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "libfyaml: parsed OK"

--- a/samples/parse_string/src/main.c
+++ b/samples/parse_string/src/main.c
@@ -1,0 +1,68 @@
+/*
+ * libfyaml on Zephyr - parse a YAML document from an in-memory buffer.
+ *
+ * Demonstrates the embedded use case: the YAML never touches a filesystem.
+ * Here it is a static string, but it could equally be a buffer filled from
+ * BLE, Wi-Fi or a UART.
+ *
+ * SPDX-License-Identifier: MIT
+ */
+#include <zephyr/kernel.h>
+#include <stdio.h>
+
+#include <libfyaml.h>
+
+/* A YAML config blob, as if just received over the air. */
+static const char yaml[] =
+	"device:\n"
+	"  name: sensor-hub\n"
+	"  id: 42\n"
+	"  enabled: true\n"
+	"network:\n"
+	"  ssid: makerville\n"
+	"  channels: [1, 6, 11]\n";
+
+int main(void)
+{
+	struct fy_document *fyd;
+	struct fy_node *root, *n;
+	const char *name, *ssid;
+	int id = -1;
+	int rc;
+
+	printf("libfyaml %s - parsing %zu bytes of YAML from RAM\n",
+	       fy_library_version(), sizeof(yaml) - 1);
+
+	/* Build a document tree directly from the in-memory string. */
+	fyd = fy_document_build_from_string(NULL, yaml, FY_NT);
+	if (!fyd) {
+		printf("libfyaml: parse FAILED\n");
+		return 1;
+	}
+
+	root = fy_document_root(fyd);
+
+	/* Path lookups into the tree. */
+	n = fy_node_by_path(root, "/device/name", FY_NT, FYNWF_DONT_FOLLOW);
+	name = n ? fy_node_get_scalar0(n) : NULL;
+
+	n = fy_node_by_path(root, "/network/ssid", FY_NT, FYNWF_DONT_FOLLOW);
+	ssid = n ? fy_node_get_scalar0(n) : NULL;
+
+	/* Typed extraction with a scanf-style helper. */
+	rc = fy_document_scanf(fyd, "/device/id %d", &id);
+
+	printf("  device.name  = %s\n", name ? name : "(null)");
+	printf("  device.id    = %s (%d)\n", rc == 1 ? "ok" : "miss", id);
+	printf("  network.ssid = %s\n", ssid ? ssid : "(null)");
+
+	fy_document_destroy(fyd);
+
+	if (name && ssid && rc == 1) {
+		printf("libfyaml: parsed OK\n");
+		return 0;
+	}
+
+	printf("libfyaml: parse incomplete\n");
+	return 1;
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -233,4 +233,5 @@ EXTRA_DIST =  \
 	getopt/getopt.c \
 	getopt/getopt.h \
 	util/fy-win32.h \
+	util/fy-picolibc.h \
 	check/fy-check.h

--- a/src/lib/fy-diag.c
+++ b/src/lib/fy-diag.c
@@ -16,6 +16,11 @@
 #include <errno.h>
 #include <stdarg.h>
 #include <ctype.h>
+#ifndef _WIN32
+#include <unistd.h>	/* isatty */
+#endif
+
+#include "fy-picolibc.h"	/* isatty() shim on picolibc */
 
 #include <libfyaml.h>
 

--- a/src/lib/fy-emit.c
+++ b/src/lib/fy-emit.c
@@ -16,6 +16,11 @@
 #include <limits.h>
 #include <ctype.h>
 #include <errno.h>
+#ifndef _WIN32
+#include <unistd.h>	/* isatty, STDOUT_FILENO, STDERR_FILENO */
+#endif
+
+#include "fy-picolibc.h"	/* isatty()/STD*_FILENO shims on picolibc */
 
 #include <libfyaml.h>
 

--- a/src/lib/fy-input.c
+++ b/src/lib/fy-input.c
@@ -22,8 +22,10 @@
 
 #ifndef _WIN32
 #include <unistd.h>
+#if !defined(__PICOLIBC__)
 #include <sys/mman.h>
 #include <sys/ioctl.h>
+#endif
 #endif
 
 #include <libfyaml.h>
@@ -335,7 +337,9 @@ void fy_input_close(struct fy_input *fyi)
 	case fyit_fd:
 
 		if (fyi->addr) {
+#if !defined(__PICOLIBC__)
 			munmap(fyi->addr, fyi->length);
+#endif
 			fyi->addr = NULL;
 		}
 
@@ -600,7 +604,9 @@ int fy_reader_input_open(struct fy_reader *fyr, struct fy_input *fyi, const stru
 
 		fyi->length = sb.st_size;
 
-		/* only map if not zero (and is not disabled) */
+		/* only map if not zero (and is not disabled);
+		 * picolibc has no mmap, fall through to the stdio/read path */
+#if !defined(__PICOLIBC__)
 		if (sb.st_size > 0 && !fyr->current_input_cfg.disable_mmap_opt) {
 			fyi->addr = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, fyi->fd, 0);
 
@@ -611,6 +617,7 @@ int fy_reader_input_open(struct fy_reader *fyr, struct fy_input *fyi, const stru
 				fyi->addr = NULL;
 			}
 		}
+#endif
 		/* if we've managed to mmap, we' good */
 		if (fyi->addr)
 			break;

--- a/src/util/fy-picolibc.h
+++ b/src/util/fy-picolibc.h
@@ -1,0 +1,45 @@
+/*
+ * fy-picolibc.h - picolibc compatibility layer
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * picolibc is the C library used by most Zephyr targets. Like the Windows
+ * layer in fy-win32.h, this header supplies the few POSIX facilities picolibc
+ * does not expose, so the rest of libfyaml can stay POSIX-shaped.
+ *
+ * It keys on __PICOLIBC__ (defined by the C library itself), not on the OS, so
+ * builds against a full-featured C library - glibc on native_sim, newlib, etc.
+ * - are unaffected.
+ */
+#ifndef FY_PICOLIBC_H
+#define FY_PICOLIBC_H
+
+/* Pull in the C library's feature header so __PICOLIBC__ becomes visible. */
+#include <stdint.h>
+
+#ifdef __PICOLIBC__
+
+/*
+ * picolibc gates isatty() behind feature macros Zephyr does not satisfy and
+ * ships no implementation for it. The console is never an interactive terminal
+ * here, so always report "not a tty".
+ */
+#ifndef isatty
+static inline int fy_picolibc_isatty(int fd) { (void)fd; return 0; }
+#define isatty(fd) fy_picolibc_isatty(fd)
+#endif
+
+/* Standard file-descriptor numbers, absent from picolibc's <unistd.h>. */
+#ifndef STDIN_FILENO
+#define STDIN_FILENO 0
+#endif
+#ifndef STDOUT_FILENO
+#define STDOUT_FILENO 1
+#endif
+#ifndef STDERR_FILENO
+#define STDERR_FILENO 2
+#endif
+
+#endif /* __PICOLIBC__ */
+
+#endif /* FY_PICOLIBC_H */

--- a/src/util/fy-utils.c
+++ b/src/util/fy-utils.c
@@ -18,12 +18,14 @@
 #include <ctype.h>
 
 #ifndef _WIN32
-#include <termios.h>
 #include <unistd.h>
-#include <sys/select.h>
-#include <sys/time.h>
 #include <sys/types.h>
 #include <fcntl.h>
+#if !defined(__PICOLIBC__)
+#include <termios.h>
+#include <sys/select.h>
+#include <sys/time.h>
+#endif
 #endif
 
 #include "fy-win32.h"
@@ -417,8 +419,9 @@ int fy_tag_scan(const char *data, size_t len, struct fy_tag_scan_info *info)
 }
 
 /* simple terminal methods; mainly for getting size of terminal */
-/* These functions are not available on Windows */
+/* These functions are not available on Windows or picolibc */
 #ifndef _WIN32
+#if !defined(__PICOLIBC__)
 static int
 fy_term_set_raw(int fd, struct termios *oldt)
 {
@@ -660,6 +663,18 @@ int fy_term_query_size(int fd, int *rows, int *cols)
 
 	return ret;
 }
+
+#else /* picolibc - no terminal */
+
+int fy_term_query_size(int fd, int *rows, int *cols)
+{
+	(void)fd;
+	(void)rows;
+	(void)cols;
+	return -1;
+}
+
+#endif /* !__PICOLIBC__ */
 
 #else /* _WIN32 */
 
@@ -962,7 +977,12 @@ struct fy_memstream *fy_memstream_open(FILE **fpp)
 		return NULL;
 	memset(fyms, 0, sizeof(*fyms));
 #if !defined(_WIN32)
+#if defined(__PICOLIBC__)
+	/* no open_memstream on picolibc: emit-to-string unsupported */
+	fyms->fp = NULL;
+#else
 	fyms->fp = open_memstream(&fyms->buf, &fyms->size);
+#endif
 #else
 	fyms->fp = tmpfile();
 #endif

--- a/src/util/fy-utils.h
+++ b/src/util/fy-utils.h
@@ -23,8 +23,10 @@
 
 #ifndef _WIN32
 #include <unistd.h>
+#if !defined(__PICOLIBC__)
 #include <termios.h>
-#include <sys/uio.h>
+#include <sys/uio.h>	/* iovec comes from libfyaml-util.h on picolibc */
+#endif
 #endif
 
 #include "fy-win32.h"

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,0 +1,82 @@
+# libfyaml Zephyr module - in-memory YAML 1.2 / JSON parser
+# SPDX-License-Identifier: MIT
+
+if(CONFIG_LIBFYAML)
+
+zephyr_library()
+
+set(FY_DIR ${ZEPHYR_CURRENT_MODULE_DIR})
+
+# Public API headers, exposed to the application: #include <libfyaml.h>
+zephyr_include_directories(${FY_DIR}/include)
+
+# Private include paths for the library translation units.
+zephyr_library_include_directories(
+  ${FY_DIR}/zephyr/include   # forced config.h
+  ${FY_DIR}/include
+  ${FY_DIR}/src
+  ${FY_DIR}/src/lib
+  ${FY_DIR}/src/util
+  ${FY_DIR}/src/xxhash
+  ${FY_DIR}/src/allocator
+)
+
+zephyr_library_compile_definitions(
+  HAVE_CONFIG_H=1
+  _GNU_SOURCE=1
+)
+
+# libfyaml intentionally uses constructs Zephyr's default warning set flags.
+zephyr_library_compile_options(
+  -Wno-unused-parameter
+  -Wno-sign-compare
+)
+
+zephyr_library_sources(
+  # --- core library ---
+  ${FY_DIR}/src/lib/fy-accel.c
+  ${FY_DIR}/src/lib/fy-atom.c
+  ${FY_DIR}/src/lib/fy-composer.c
+  ${FY_DIR}/src/lib/fy-diag.c
+  ${FY_DIR}/src/lib/fy-doc.c
+  ${FY_DIR}/src/lib/fy-docbuilder.c
+  ${FY_DIR}/src/lib/fy-docstate.c
+  ${FY_DIR}/src/lib/fy-dump.c
+  ${FY_DIR}/src/lib/fy-emit.c
+  ${FY_DIR}/src/lib/fy-event.c
+  ${FY_DIR}/src/lib/fy-input.c
+  ${FY_DIR}/src/lib/fy-parse.c
+  ${FY_DIR}/src/lib/fy-path.c
+  ${FY_DIR}/src/lib/fy-token.c
+  ${FY_DIR}/src/lib/fy-types.c
+  ${FY_DIR}/src/lib/fy-walk.c
+
+  # --- diagnostics ---
+  ${FY_DIR}/src/lib/fy-composer-diag.c
+  ${FY_DIR}/src/lib/fy-doc-diag.c
+  ${FY_DIR}/src/lib/fy-docbuilder-diag.c
+  ${FY_DIR}/src/lib/fy-input-diag.c
+  ${FY_DIR}/src/lib/fy-parse-diag.c
+
+  # --- utilities ---
+  ${FY_DIR}/src/util/fy-blob.c
+  ${FY_DIR}/src/util/fy-ctype.c
+  ${FY_DIR}/src/util/fy-utf8.c
+  ${FY_DIR}/src/util/fy-utils.c
+
+  # --- hashing (xxhash; BLAKE3 deliberately omitted) ---
+  ${FY_DIR}/src/xxhash/xxhash.c
+)
+
+# Deliberately excluded for the in-memory build:
+#   src/allocator/*         - allocator subsystem is used only by the generic
+#                             builder (HAVE_GENERIC off); the classic document
+#                             tree allocates with plain malloc/free. Dropping it
+#                             avoids the mmap/mremap/pthread/sysconf POSIX deps.
+#   src/lib/fy-cache.c      - parse cache (inert without HAVE_GENERIC)
+#   src/blake3/*            - only used by the parse cache
+#   src/thread/fy-thread.c  - only used by BLAKE3's SIMD dispatcher
+#   src/generic/*           - generic subsystem (HAVE_GENERIC off)
+#   src/reflection/*        - needs libclang (host only)
+
+endif()

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1,0 +1,14 @@
+# libfyaml Zephyr module
+# SPDX-License-Identifier: MIT
+
+config LIBFYAML
+	bool "libfyaml YAML 1.2 / JSON parser"
+	help
+	  Enable libfyaml, a fully-featured YAML 1.2 and JSON parser, document
+	  model and emitter.
+
+	  This Zephyr build targets in-memory use: parse YAML/JSON from a RAM
+	  buffer (fy_parser_set_string / fy_document_build_from_string) or from
+	  a streamed pull callback (fy_parser_set_input_callback). No filesystem
+	  is required. The on-disk parse cache, reflection and generic
+	  subsystems are not built.

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,4 @@
+name: libfyaml
+build:
+  cmake: zephyr
+  kconfig: zephyr/Kconfig


### PR DESCRIPTION
picolibc is the C library used by most Zephyr (and other bare-metal) targets. Unlike glibc/newlib it does not expose a number of POSIX facilities, which previously broke the build. This adds support in the same spirit as the existing Windows layer (fy-win32.h): a small compatibility shim plus capability-gated branches, keyed on the C library's own __PICOLIBC__ macro rather than on any OS.

  - src/util/fy-picolibc.h: new compat header (the picolibc analog of fy-win32.h) providing isatty() and the STD*_FILENO macros that picolibc omits.
  - libfyaml-util.h: provide struct iovec and SSIZE_MAX (no <sys/uio.h>).
  - libfyaml-endian.h: derive byte order from the compiler's __BYTE_ORDER__ builtins (no <endian.h>).
  - libfyaml-align.h: use C11 aligned_alloc() (no posix_memalign()).
  - fy-utils.{c,h}: skip <termios.h>/<sys/uio.h>; stub the terminal-size query; emit-to-string (open_memstream) reported unsupported.
  - fy-diag.c, fy-emit.c: include <unistd.h> for isatty()/STD*_FILENO (previously relied on transitive inclusion that picolibc lacks).
