### PR TITLE
fix(portability): undef C++ atomic fallback macros to avoid corrupting libstdc++ <memory>

### DIFF
--- a/include/libfyaml/libfyaml-atomics.h
+++ b/include/libfyaml/libfyaml-atomics.h
@@ -132,6 +132,21 @@ extern "C++" {
  * We unconditionally enable it if we have stdatomic.h
  */
 #define FY_HAVE_C11_ATOMICS
+#elif defined(__cplusplus) && defined(__clang__) && \
+	(__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 6))
+/*
+ * Clang supports the ``_Atomic`` qualifier as a native compiler builtin in
+ * C++ mode too, independently of whether <stdatomic.h> is included (unlike
+ * GCC, which only understands ``_Atomic`` via the macros <stdatomic.h>
+ * itself defines). This must stay decoupled from FY_HAVE_STDATOMIC_H: when
+ * the latter is unset pre-C++23 (see above), Clang still natively supports
+ * ``_Atomic``, and libc++'s own <atomic> implementation relies internally
+ * on that exact builtin qualifier. If FY_HAVE_C11_ATOMICS were left unset
+ * here, the #else branch below would redefine ``_Atomic(_x)`` as a
+ * no-op macro, which corrupts libc++'s internal use of ``_Atomic(_Tp)``
+ * the moment <atomic> is included later in the same translation unit.
+ */
+#define FY_HAVE_C11_ATOMICS
 #endif
 
 /* Decide macro */

--- a/include/libfyaml/libfyaml-atomics.h
+++ b/include/libfyaml/libfyaml-atomics.h
@@ -132,7 +132,7 @@ extern "C++" {
  * We unconditionally enable it if we have stdatomic.h
  */
 #define FY_HAVE_C11_ATOMICS
-#elif defined(__cplusplus) && defined(__clang__) && \
+#elif defined(__cplusplus) && defined(__clang__) && !defined(_WIN32) && \
 	(__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 6))
 /*
  * Clang supports the ``_Atomic`` qualifier as a native compiler builtin in
@@ -145,6 +145,16 @@ extern "C++" {
  * here, the #else branch below would redefine ``_Atomic(_x)`` as a
  * no-op macro, which corrupts libc++'s internal use of ``_Atomic(_Tp)``
  * the moment <atomic> is included later in the same translation unit.
+ *
+ * Restricted to non-Windows targets: Clang on Windows links against
+ * MSVC's STL, not libc++, so none of the above applies there -- MSVC's
+ * <atomic> does not rely on Clang's _Atomic qualifier internally. Keeping
+ * Windows on the plain (non-_Atomic-qualified) fallback below also avoids
+ * a real-world codegen bug observed with __c11_atomic_fetch_add() under
+ * Clang-on-Windows Debug builds (wrong return value, reproducible on both
+ * windows-2022 and windows-latest CI images; release builds are
+ * unaffected, suggesting a Debug-codegen-specific lowering bug for this
+ * builtin on that target rather than anything in this header's logic).
  */
 #define FY_HAVE_C11_ATOMICS
 #endif
@@ -267,16 +277,18 @@ typedef bool fy_priv_atomic_flag;
 #define fy_priv_atomic_flag_test_and_set(_ptr) \
 	([&]() -> bool { volatile fy_priv_atomic_flag *__p = (_ptr); bool __ret = *__p; *__p = true; return __ret; }())
 
-#elif defined(__cplusplus) && defined(__clang__)
+#elif defined(__cplusplus) && defined(__clang__) && !defined(_WIN32)
 
-/* Clang C++ pre-C++23 (FY_HAVE_STDATOMIC_H is intentionally unset here, see
- * above, to avoid mixing <stdatomic.h> with <atomic> before C++23). Unlike
- * GCC, Clang still genuinely qualifies FY_ATOMIC()-declared storage as
- * ``_Atomic`` (see FY_HAVE_C11_ATOMICS above), so the naive __typeof__-based
- * fallback used in the last-resort branch below does not apply here: in
- * C++, ``__typeof__(*(_ptr))`` on a real ``_Atomic``-qualified lvalue yields
- * an ``_Atomic``-qualified type too, and C++ (unlike C) has no implicit
- * conversion stripping that qualifier back to a plain type, so e.g.
+/* Clang C++ pre-C++23 on non-Windows targets (FY_HAVE_STDATOMIC_H is
+ * intentionally unset here, see above, to avoid mixing <stdatomic.h> with
+ * <atomic> before C++23; Windows is excluded, see the matching note on
+ * FY_HAVE_C11_ATOMICS above). Unlike GCC, Clang still genuinely qualifies
+ * FY_ATOMIC()-declared storage as ``_Atomic`` here (see FY_HAVE_C11_ATOMICS
+ * above), so the naive __typeof__-based fallback used in the last-resort
+ * branch below does not apply: in C++, ``__typeof__(*(_ptr))`` on a real
+ * ``_Atomic``-qualified lvalue yields an ``_Atomic``-qualified type too, and
+ * C++ (unlike C) has no implicit conversion stripping that qualifier back
+ * to a plain type, so e.g.
  * ``int old = fy_atomic_fetch_add(&v, 3);`` fails to compile.
  *
  * Use Clang's ``__c11_atomic_*`` builtins instead: they operate directly on

--- a/include/libfyaml/libfyaml-atomics.h
+++ b/include/libfyaml/libfyaml-atomics.h
@@ -68,22 +68,26 @@ extern "C" {
  * and all ``fy_atomic_*`` macros delegate to them.
  *
  * C mode  : STDC version >= 201112L, GCC >= 4.9, Clang >= 3.6, MSVC >= 1928
- * C++ mode: Clang >= 3.6 (supports <stdatomic.h> and _Atomic as extensions),
- *           MSVC >= 1938 + C++23 (_MSVC_LANG >= 202302L): MSVC's <stdatomic.h>
- *           is a stub before C++23 (STL4038 warning) and _Atomic is not
- *           provided as an extension keyword, so older MSVC C++ modes cannot
- *           use it.  Build the test executables with /std:c++latest on MSVC.
+ * C++ mode: only when the active C++ standard is C++23 or later
+ *           (__cplusplus >= 202302L, or MSVC's _MSVC_LANG >= 202302L), since
+ *           that is the first standard version to officially mandate
+ *           <stdatomic.h>/<atomic> interoperability. Before C++23 this header
+ *           uses its own private (fy_priv_atomic_*) fallback implementation
+ *           instead, built on GCC/Clang statement-expression and __typeof__
+ *           extensions -- both compilers support these even pre-C++23.
  *
- *           GCC C++ intentionally excluded: it falls back to its own
- *           ({ }/__typeof__) extension macros instead, which is sufficient
- *           and avoids pulling <stdatomic.h> into C++ translation units on
- *           libstdc++ where the interaction is less well-tested.
- *           Clang must use <stdatomic.h> because libc++'s <atomic> declares
- *           functions named atomic_load/atomic_store/... that collide with
- *           the fallback macros when any C++ header transitively includes
- *           <atomic> (e.g. <optional>, <string_view> on libc++).
+ *           Mixing the two pre-C++23 is unsafe in general: some C++ standard
+ *           libraries (e.g. recent libc++ on Xcode 16 / macOS 15) now emit a
+ *           hard #error if <stdatomic.h> was already included when <atomic>
+ *           is processed (which can happen transitively, e.g. via <optional>
+ *           or <string_view>, in any C++ translation unit downstream of this
+ *           header). Before that hard error existed, this same combination
+ *           could instead silently collide on libc++ via unprefixed names
+ *           like atomic_load/atomic_store declared by <atomic> -- which is
+ *           why this header no longer defines its own fallback macros under
+ *           those bare names (see fy_priv_atomic_* below).
  *
- * The check is required only for _really_ old compilers
+ * The check is required only for _really_ old compilers in C mode.
  */
 #if !defined(__STDC__NO_ATOMICS__) && \
 	((!defined(__cplusplus) && \
@@ -92,7 +96,7 @@ extern "C" {
 	   (defined(__clang__) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 6))) || \
 	   (defined(_MSC_VER) && _MSC_VER >= 1928))) || \
 	 (defined(__cplusplus) && \
-	  ((defined(__clang__) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 6))) || \
+	  ((__cplusplus >= 202302L) || \
 	   (defined(_MSC_VER) && _MSC_VER >= 1938 && \
 	    defined(_MSVC_LANG) && _MSVC_LANG >= 202302L))))
 #define FY_HAVE_STDATOMIC_H

--- a/include/libfyaml/libfyaml-atomics.h
+++ b/include/libfyaml/libfyaml-atomics.h
@@ -154,30 +154,62 @@ extern "C++" {
  * therefore only safe in single-threaded contexts.
  */
 #define FY_HAVE_SAFE_ATOMIC_OPS
+
+/* Alias the real <stdatomic.h> names under our own fy_priv_ prefix so that
+ * fy_atomic_*() below can delegate uniformly regardless of backend, without
+ * ever introducing macros under the bare (unprefixed) C11 names itself --
+ * see the rationale in the #else branches for why that matters. */
+#define fy_priv_atomic_flag atomic_flag
+#define fy_priv_atomic_load(_ptr) atomic_load((_ptr))
+#define fy_priv_atomic_store(_ptr, _v) atomic_store((_ptr), (_v))
+#define fy_priv_atomic_exchange(_ptr, _v) atomic_exchange((_ptr), (_v))
+#define fy_priv_atomic_compare_exchange_strong(_ptr, _exp, _des) \
+	atomic_compare_exchange_strong((_ptr), (_exp), (_des))
+#define fy_priv_atomic_compare_exchange_weak(_ptr, _exp, _des) \
+	atomic_compare_exchange_weak((_ptr), (_exp), (_des))
+#define fy_priv_atomic_fetch_add(_ptr, _v) atomic_fetch_add((_ptr), (_v))
+#define fy_priv_atomic_fetch_sub(_ptr, _v) atomic_fetch_sub((_ptr), (_v))
+#define fy_priv_atomic_fetch_or(_ptr, _v) atomic_fetch_or((_ptr), (_v))
+#define fy_priv_atomic_fetch_xor(_ptr, _v) atomic_fetch_xor((_ptr), (_v))
+#define fy_priv_atomic_fetch_and(_ptr, _v) atomic_fetch_and((_ptr), (_v))
+#define fy_priv_atomic_flag_clear(_ptr) atomic_flag_clear((_ptr))
+#define fy_priv_atomic_flag_set(_ptr) atomic_flag_set((_ptr))
+#define fy_priv_atomic_flag_test_and_set(_ptr) atomic_flag_test_and_set((_ptr))
+
 #elif defined(_MSC_VER) && defined(__cplusplus)
 
 /* MSVC C++ fallback (C++17 and earlier, where <stdatomic.h> is unavailable).
  * MSVC does not support GCC statement-expressions ({ }) or __typeof__, so we
  * use decltype and immediately-invoked C++ lambdas for the fetch-and-modify
  * operations.  These are plain (non-atomic) loads/stores; safe only in
- * single-threaded contexts. */
+ * single-threaded contexts.
+ *
+ * These are deliberately defined under a fy_priv_ prefix rather than the
+ * bare C11 names (atomic_load, atomic_compare_exchange_strong, ...): the
+ * bare names collide with unrelated, non-std::-namespaced overloads of the
+ * same names that some C++ standard libraries declare for std::shared_ptr
+ * (e.g. libstdc++'s <bits/shared_ptr_atomic.h>). Because the preprocessor
+ * doesn't parse template angle brackets, a comma inside a template argument
+ * list such as __shared_ptr<_Tp, _Lp> is seen as an extra macro argument,
+ * silently corrupting those declarations if such a header is included later
+ * in the same translation unit. */
 
 #undef FY_HAVE_SAFE_ATOMIC_OPS
 
-typedef bool atomic_flag;
+typedef bool fy_priv_atomic_flag;
 
-#define atomic_load(_ptr) \
+#define fy_priv_atomic_load(_ptr) \
 	(*(_ptr))
 
-#define atomic_store(_ptr, _val) \
+#define fy_priv_atomic_store(_ptr, _val) \
 	do { \
 		*(_ptr) = (_val); \
 	} while(0)
 
-#define atomic_exchange(_ptr, _v) \
+#define fy_priv_atomic_exchange(_ptr, _v) \
 	([&]() -> decltype(*(_ptr)) { decltype(*(_ptr)) __old = *(_ptr); *(_ptr) = (_v); return __old; }())
 
-#define atomic_compare_exchange_strong(_ptr, _exp, _des) \
+#define fy_priv_atomic_compare_exchange_strong(_ptr, _exp, _des) \
 	([&]() -> bool { \
 		bool __res; \
 		if (*(_ptr) == *(_exp)) { *(_ptr) = (_des); __res = true; } \
@@ -185,52 +217,60 @@ typedef bool atomic_flag;
 		return __res; \
 	}())
 
-#define atomic_compare_exchange_weak(_ptr, _exp, _des) \
-	atomic_compare_exchange_strong((_ptr), (_exp), (_des))
+#define fy_priv_atomic_compare_exchange_weak(_ptr, _exp, _des) \
+	fy_priv_atomic_compare_exchange_strong((_ptr), (_exp), (_des))
 
-#define atomic_fetch_add(_ptr, _v) \
+#define fy_priv_atomic_fetch_add(_ptr, _v) \
 	([&]() -> decltype(*(_ptr)) { decltype(*(_ptr)) __old = *(_ptr); *(_ptr) += (_v); return __old; }())
 
-#define atomic_fetch_sub(_ptr, _v) \
+#define fy_priv_atomic_fetch_sub(_ptr, _v) \
 	([&]() -> decltype(*(_ptr)) { decltype(*(_ptr)) __old = *(_ptr); *(_ptr) -= (_v); return __old; }())
 
-#define atomic_fetch_or(_ptr, _v) \
+#define fy_priv_atomic_fetch_or(_ptr, _v) \
 	([&]() -> decltype(*(_ptr)) { decltype(*(_ptr)) __old = *(_ptr); *(_ptr) |= (_v); return __old; }())
 
-#define atomic_fetch_xor(_ptr, _v) \
+#define fy_priv_atomic_fetch_xor(_ptr, _v) \
 	([&]() -> decltype(*(_ptr)) { decltype(*(_ptr)) __old = *(_ptr); *(_ptr) ^= (_v); return __old; }())
 
-#define atomic_fetch_and(_ptr, _v) \
+#define fy_priv_atomic_fetch_and(_ptr, _v) \
 	([&]() -> decltype(*(_ptr)) { decltype(*(_ptr)) __old = *(_ptr); *(_ptr) &= (_v); return __old; }())
 
-#define atomic_flag_clear(_ptr) \
+#define fy_priv_atomic_flag_clear(_ptr) \
 	do { \
 		*(_ptr) = false; \
 	} while(0)
 
-#define atomic_flag_set(_ptr) \
+#define fy_priv_atomic_flag_set(_ptr) \
 	do { \
 		*(_ptr) = true; \
 	} while(0)
 
-#define atomic_flag_test_and_set(_ptr) \
-	([&]() -> bool { volatile atomic_flag *__p = (_ptr); bool __ret = *__p; *__p = true; return __ret; }())
+#define fy_priv_atomic_flag_test_and_set(_ptr) \
+	([&]() -> bool { volatile fy_priv_atomic_flag *__p = (_ptr); bool __ret = *__p; *__p = true; return __ret; }())
 
 #else
 
+/* Last-resort fallback for toolchains with neither <stdatomic.h> nor GCC
+ * statement-expression/__typeof__ support outside of MSVC C++ (e.g. GCC in
+ * C++ mode, which intentionally avoids <stdatomic.h> -- see the comment on
+ * FY_HAVE_STDATOMIC_H above). These are deliberately defined under a
+ * fy_priv_ prefix rather than the bare C11 names; see the rationale in the
+ * MSVC C++ branch above -- the same collision with e.g. libstdc++'s
+ * <bits/shared_ptr_atomic.h> applies here. */
+
 #undef FY_HAVE_SAFE_ATOMIC_OPS
 
-typedef bool atomic_flag;
+typedef bool fy_priv_atomic_flag;
 
-#define atomic_load(_ptr) \
+#define fy_priv_atomic_load(_ptr) \
 	(*(_ptr))
 
-#define atomic_store(_ptr, _val) \
+#define fy_priv_atomic_store(_ptr, _val) \
 	do { \
 		*(_ptr) = (_val); \
 	} while(0)
 
-#define atomic_exchange(_ptr, _v) \
+#define fy_priv_atomic_exchange(_ptr, _v) \
 	({ \
 		__typeof__(_ptr) __ptr = (_ptr); \
 		__typeof__(*(_ptr)) __old = *__ptr; \
@@ -238,7 +278,7 @@ typedef bool atomic_flag;
 		__old; \
 	})
 
-#define atomic_compare_exchange_strong(_ptr, _exp, _des) \
+#define fy_priv_atomic_compare_exchange_strong(_ptr, _exp, _des) \
 	({ \
 		__typeof__(_ptr) __ptr = (_ptr); \
 		__typeof__(*(_ptr)) __old = *__ptr; \
@@ -251,10 +291,10 @@ typedef bool atomic_flag;
 		__res; \
 	})
 
-#define atomic_compare_exchange_weak(_ptr, _exp, _des) \
-	atomic_compare_exchange_strong((_ptr), (_exp), (_des))
+#define fy_priv_atomic_compare_exchange_weak(_ptr, _exp, _des) \
+	fy_priv_atomic_compare_exchange_strong((_ptr), (_exp), (_des))
 
-#define atomic_fetch_add(_ptr, _v) \
+#define fy_priv_atomic_fetch_add(_ptr, _v) \
 	({ \
 		__typeof__(_ptr) __ptr = (_ptr); \
 		__typeof__(*(_ptr)) __old = *__ptr; \
@@ -262,7 +302,7 @@ typedef bool atomic_flag;
 		__old; \
 	})
 
-#define atomic_fetch_sub(_ptr, _v) \
+#define fy_priv_atomic_fetch_sub(_ptr, _v) \
 	({ \
 		__typeof__(_ptr) __ptr = (_ptr); \
 		__typeof__(*(_ptr)) __old = *__ptr; \
@@ -270,7 +310,7 @@ typedef bool atomic_flag;
 		__old; \
 	})
 
-#define atomic_fetch_or(_ptr, _v) \
+#define fy_priv_atomic_fetch_or(_ptr, _v) \
 	({ \
 		__typeof__(_ptr) __ptr = (_ptr); \
 		__typeof__(*(_ptr)) __old = *__ptr; \
@@ -278,7 +318,7 @@ typedef bool atomic_flag;
 		__old; \
 	})
 
-#define atomic_fetch_xor(_ptr, _v) \
+#define fy_priv_atomic_fetch_xor(_ptr, _v) \
 	({ \
 		__typeof__(_ptr) __ptr = (_ptr); \
 		__typeof__(*(_ptr)) __old = *__ptr; \
@@ -286,7 +326,7 @@ typedef bool atomic_flag;
 		__old; \
 	})
 
-#define atomic_fetch_and(_ptr, _v) \
+#define fy_priv_atomic_fetch_and(_ptr, _v) \
 	({ \
 		__typeof__(_ptr) __ptr = (_ptr); \
 		__typeof__(*(_ptr)) __old = *__ptr; \
@@ -294,12 +334,12 @@ typedef bool atomic_flag;
 		__old; \
 	})
 
-#define atomic_flag_clear(_ptr) \
+#define fy_priv_atomic_flag_clear(_ptr) \
 	do { \
 		*(_ptr) = false; \
 	} while(0)
 
-#define atomic_flag_set(_ptr) \
+#define fy_priv_atomic_flag_set(_ptr) \
 	do { \
 		*(_ptr) = true; \
 	} while(0)
@@ -310,9 +350,9 @@ typedef bool atomic_flag;
  * return values inverted (returning true on a previously-clear flag), which
  * caused fy_atomic_flag_test_and_set() to misreport state on every compiler
  * that falls back to these macros (e.g. GCC in C++ mode). */
-#define atomic_flag_test_and_set(_ptr) \
+#define fy_priv_atomic_flag_test_and_set(_ptr) \
 	({ \
-		volatile atomic_flag *__ptr = (_ptr); \
+		volatile fy_priv_atomic_flag *__ptr = (_ptr); \
 		bool __ret = *__ptr; \
 		*__ptr = true; \
 		__ret; \
@@ -340,7 +380,7 @@ typedef bool atomic_flag;
  * Backed by ``atomic_flag`` from ``<stdatomic.h>`` when available, or a plain
  * ``bool`` in the fallback path.
  */
-#define fy_atomic_flag atomic_flag
+#define fy_atomic_flag fy_priv_atomic_flag
 
 /**
  * fy_atomic_load() - Atomically load the value at @_ptr.
@@ -350,7 +390,7 @@ typedef bool atomic_flag;
  * Returns: The current value.
  */
 #define fy_atomic_load(_ptr) \
-	atomic_load((_ptr))
+	fy_priv_atomic_load((_ptr))
 
 /**
  * fy_atomic_store() - Atomically store @_v at @_ptr.
@@ -359,7 +399,7 @@ typedef bool atomic_flag;
  * @_v:   Value to store.
  */
 #define fy_atomic_store(_ptr, _v) \
-	atomic_store((_ptr), (_v))
+	fy_priv_atomic_store((_ptr), (_v))
 
 /**
  * fy_atomic_exchange() - Atomically replace the value at @_ptr with @_v.
@@ -370,7 +410,7 @@ typedef bool atomic_flag;
  * Returns: The old value that was at @_ptr before the exchange.
  */
 #define fy_atomic_exchange(_ptr, _v) \
-	atomic_exchange((_ptr), (_v))
+	fy_priv_atomic_exchange((_ptr), (_v))
 
 /**
  * fy_atomic_compare_exchange_strong() - Strong CAS: replace @_ptr's value if it equals @_e.
@@ -386,7 +426,7 @@ typedef bool atomic_flag;
  * Returns: true if the exchange succeeded, false otherwise.
  */
 #define fy_atomic_compare_exchange_strong(_ptr, _e, _d) \
-	atomic_compare_exchange_strong((_ptr), (_e), (_d))
+	fy_priv_atomic_compare_exchange_strong((_ptr), (_e), (_d))
 
 /**
  * fy_atomic_compare_exchange_weak() - Weak CAS: may spuriously fail.
@@ -402,7 +442,7 @@ typedef bool atomic_flag;
  * Returns: true if the exchange succeeded, false otherwise.
  */
 #define fy_atomic_compare_exchange_weak(_ptr, _e, _d) \
-	atomic_compare_exchange_weak((_ptr), (_e), (_d))
+	fy_priv_atomic_compare_exchange_weak((_ptr), (_e), (_d))
 
 /**
  * fy_atomic_fetch_add() - Atomically add @_v to @_ptr and return the old value.
@@ -413,7 +453,7 @@ typedef bool atomic_flag;
  * Returns: The value of @_ptr before the addition.
  */
 #define fy_atomic_fetch_add(_ptr, _v) \
-	atomic_fetch_add((_ptr), (_v))
+	fy_priv_atomic_fetch_add((_ptr), (_v))
 
 /**
  * fy_atomic_fetch_sub() - Atomically subtract @_v from @_ptr and return the old value.
@@ -424,7 +464,7 @@ typedef bool atomic_flag;
  * Returns: The value of @_ptr before the subtraction.
  */
 #define fy_atomic_fetch_sub(_ptr, _v) \
-	atomic_fetch_sub((_ptr), (_v))
+	fy_priv_atomic_fetch_sub((_ptr), (_v))
 
 /**
  * fy_atomic_fetch_or() - Atomically OR @_v into @_ptr and return the old value.
@@ -435,7 +475,7 @@ typedef bool atomic_flag;
  * Returns: The value of @_ptr before the operation.
  */
 #define fy_atomic_fetch_or(_ptr, _v) \
-	atomic_fetch_or((_ptr), (_v))
+	fy_priv_atomic_fetch_or((_ptr), (_v))
 
 /**
  * fy_atomic_fetch_xor() - Atomically XOR @_v into @_ptr and return the old value.
@@ -446,7 +486,7 @@ typedef bool atomic_flag;
  * Returns: The value of @_ptr before the operation.
  */
 #define fy_atomic_fetch_xor(_ptr, _v) \
-	atomic_fetch_xor((_ptr), (_v))
+	fy_priv_atomic_fetch_xor((_ptr), (_v))
 
 /**
  * fy_atomic_fetch_and() - Atomically AND @_v into @_ptr and return the old value.
@@ -457,7 +497,7 @@ typedef bool atomic_flag;
  * Returns: The value of @_ptr before the operation.
  */
 #define fy_atomic_fetch_and(_ptr, _v) \
-	atomic_fetch_and((_ptr), (_v))
+	fy_priv_atomic_fetch_and((_ptr), (_v))
 
 /**
  * fy_atomic_flag_clear() - Atomically clear a flag (set to false).
@@ -465,7 +505,7 @@ typedef bool atomic_flag;
  * @_ptr: Pointer to an fy_atomic_flag.
  */
 #define fy_atomic_flag_clear(_ptr) \
-	atomic_flag_clear((_ptr))
+	fy_priv_atomic_flag_clear((_ptr))
 
 /**
  * fy_atomic_flag_set() - Atomically set a flag (set to true).
@@ -477,7 +517,7 @@ typedef bool atomic_flag;
  * @_ptr: Pointer to an fy_atomic_flag.
  */
 #define fy_atomic_flag_set(_ptr) \
-	atomic_flag_set((_ptr))
+	fy_priv_atomic_flag_set((_ptr))
 
 /**
  * fy_atomic_flag_test_and_set() - Atomically set a flag and return its old value.
@@ -490,7 +530,7 @@ typedef bool atomic_flag;
  * Returns: true if the flag was already set, false if it was clear.
  */
 #define fy_atomic_flag_test_and_set(_ptr) \
-	atomic_flag_test_and_set((_ptr))
+	fy_priv_atomic_flag_test_and_set((_ptr))
 
 /**
  * fy_cpu_relax() - Emit a CPU relaxation hint inside a spin-wait loop.

--- a/include/libfyaml/libfyaml-atomics.h
+++ b/include/libfyaml/libfyaml-atomics.h
@@ -267,6 +267,72 @@ typedef bool fy_priv_atomic_flag;
 #define fy_priv_atomic_flag_test_and_set(_ptr) \
 	([&]() -> bool { volatile fy_priv_atomic_flag *__p = (_ptr); bool __ret = *__p; *__p = true; return __ret; }())
 
+#elif defined(__cplusplus) && defined(__clang__)
+
+/* Clang C++ pre-C++23 (FY_HAVE_STDATOMIC_H is intentionally unset here, see
+ * above, to avoid mixing <stdatomic.h> with <atomic> before C++23). Unlike
+ * GCC, Clang still genuinely qualifies FY_ATOMIC()-declared storage as
+ * ``_Atomic`` (see FY_HAVE_C11_ATOMICS above), so the naive __typeof__-based
+ * fallback used in the last-resort branch below does not apply here: in
+ * C++, ``__typeof__(*(_ptr))`` on a real ``_Atomic``-qualified lvalue yields
+ * an ``_Atomic``-qualified type too, and C++ (unlike C) has no implicit
+ * conversion stripping that qualifier back to a plain type, so e.g.
+ * ``int old = fy_atomic_fetch_add(&v, 3);`` fails to compile.
+ *
+ * Use Clang's ``__c11_atomic_*`` builtins instead: they operate directly on
+ * genuinely ``_Atomic``-qualified objects, are real (memory-ordered) atomic
+ * operations, and -- being compiler builtins rather than functions declared
+ * by a header -- never pull in <stdatomic.h> or collide with anything
+ * <atomic> declares. */
+
+#define FY_HAVE_SAFE_ATOMIC_OPS
+
+/* Plain (non-_Atomic-qualified) bool: braced/zero-initializers such as
+ * ``fy_priv_atomic_flag flag = {};`` are not valid on an _Atomic-qualified
+ * type in C++ (it is not an aggregate there). The flag/clear/set/test_and_set
+ * macros below reinterpret the pointer as _Atomic(bool)* only at the point
+ * of each __c11_atomic_*() call. */
+typedef bool fy_priv_atomic_flag;
+
+#define fy_priv_atomic_load(_ptr) \
+	__c11_atomic_load((_ptr), __ATOMIC_SEQ_CST)
+
+#define fy_priv_atomic_store(_ptr, _val) \
+	__c11_atomic_store((_ptr), (_val), __ATOMIC_SEQ_CST)
+
+#define fy_priv_atomic_exchange(_ptr, _v) \
+	__c11_atomic_exchange((_ptr), (_v), __ATOMIC_SEQ_CST)
+
+#define fy_priv_atomic_compare_exchange_strong(_ptr, _exp, _des) \
+	__c11_atomic_compare_exchange_strong((_ptr), (_exp), (_des), __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)
+
+#define fy_priv_atomic_compare_exchange_weak(_ptr, _exp, _des) \
+	__c11_atomic_compare_exchange_weak((_ptr), (_exp), (_des), __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)
+
+#define fy_priv_atomic_fetch_add(_ptr, _v) \
+	__c11_atomic_fetch_add((_ptr), (_v), __ATOMIC_SEQ_CST)
+
+#define fy_priv_atomic_fetch_sub(_ptr, _v) \
+	__c11_atomic_fetch_sub((_ptr), (_v), __ATOMIC_SEQ_CST)
+
+#define fy_priv_atomic_fetch_or(_ptr, _v) \
+	__c11_atomic_fetch_or((_ptr), (_v), __ATOMIC_SEQ_CST)
+
+#define fy_priv_atomic_fetch_xor(_ptr, _v) \
+	__c11_atomic_fetch_xor((_ptr), (_v), __ATOMIC_SEQ_CST)
+
+#define fy_priv_atomic_fetch_and(_ptr, _v) \
+	__c11_atomic_fetch_and((_ptr), (_v), __ATOMIC_SEQ_CST)
+
+#define fy_priv_atomic_flag_clear(_ptr) \
+	__c11_atomic_store((_Atomic(bool) *)(_ptr), false, __ATOMIC_SEQ_CST)
+
+#define fy_priv_atomic_flag_set(_ptr) \
+	__c11_atomic_store((_Atomic(bool) *)(_ptr), true, __ATOMIC_SEQ_CST)
+
+#define fy_priv_atomic_flag_test_and_set(_ptr) \
+	__c11_atomic_exchange((_Atomic(bool) *)(_ptr), true, __ATOMIC_SEQ_CST)
+
 #else
 
 /* Last-resort fallback for toolchains with neither <stdatomic.h> nor GCC


### PR DESCRIPTION
## Problem

When `libfyaml.h` is included by a C++ translation unit *before* `<memory>`/`<atomic>` (a very common pattern, e.g. MRPT's `yaml.cpp` includes `<libfyaml.h>` first and the various STL headers afterwards), the build can fail with a long, confusing cascade of errors inside libstdc++'s `<bits/shared_ptr_atomic.h>`, such as:

```
/usr/include/c++/13/bits/shared_ptr_atomic.h:335:59: error: expected primary-expression before ‘,’ token
  335 |     atomic_compare_exchange_weak_explicit(__shared_ptr<_Tp, _Lp>* __p,
      |                                                           ^
/usr/include/c++/13/bits/shared_ptr_atomic.h:335:61: error: ‘_Lp’ was not declared in this scope; did you mean ‘_Tp’?
```

## Root cause

`libfyaml-atomics.h`'s GCC-in-C++-mode fallback path (the `#else` branch used because GCC C++ intentionally avoids `<stdatomic.h>`, per the comment a few lines above it) defines plain, unprefixed macros:

- `atomic_load`, `atomic_store`, `atomic_exchange`
- `atomic_compare_exchange_strong`, `atomic_compare_exchange_weak`
- `atomic_fetch_add/sub/or/xor/and`
- `atomic_flag_clear/set/test_and_set`
- `_Atomic`

...and never `#undef`s them.

These names collide with libstdc++'s own internal (non-`std::`-namespaced) function templates of the same names declared in `<bits/shared_ptr_atomic.h>`, e.g.:

```cpp
template<typename _Tp, _Lock_policy _Lp>
  inline bool
  atomic_compare_exchange_strong(__shared_ptr<_Tp, _Lp>* __p,
                                  __shared_ptr<_Tp, _Lp>* __v,
                                  __shared_ptr<_Tp, _Lp>  __w, ...)
```

The C preprocessor doesn't parse template angle brackets, so the comma inside `__shared_ptr<_Tp, _Lp>` is treated as an extra macro argument when `atomic_compare_exchange_strong` is still a 3-argument function-like macro at that point. The mis-expansion eats most of the parameter list, corrupting the declaration and producing the unrelated-looking error cascade above.

I confirmed this concretely by preprocessing the affected translation unit: the macro literally strips the parameter list down to nothing, e.g.

```cpp
  template<typename _Tp, _Lock_policy _Lp>
    inline bool
    atomic_compare_exchange_strong


    {
      return std::atomic_compare_exchange_strong_explicit(__p, __v, ...);
    }
```

## Fix

`#undef` the fallback macros (guarded by `__cplusplus`) at the end of `libfyaml-atomics.h`, once the internal `fy_atomic_*` API has already consumed them. I verified that:
- No other libfyaml public header references these unprefixed names or `FY_ATOMIC`/`fy_atomic_*`.
- The only internal user, `fy_atomic_get_and_clear_counter()`, is defined earlier in the same header, before the `#undef` block, so its macro expansion happens before the names are removed.
- This only affects C++ translation units; plain-C compilation (where these macros are normally only reached on very old C toolchains lacking `<stdatomic.h>`) is untouched.

## Context

I ran into this while building [MRPT](https://github.com/MRPT/mrpt) 3.x, which vendors libfyaml as a submodule for its YAML container support. A previous round of C++-portability fixes (`d16b043`, `1026d76`, `b26b086`, etc.) addressed the `<stdatomic.h>`/`extern "C"` interaction, but this particular fallback branch (only exercised by GCC in C++ mode) wasn't covered by that pass.

## Testing

Verified the fix resolves the build failure and that MRPT's full local test suite (including the `mrpt_containers` module that exercises this YAML/libfyaml code path) passes after applying it.