### PR TITLE
Add Haiku to the list to find endian.h

### DIFF
--- a/include/libfyaml/libfyaml-endian.h
+++ b/include/libfyaml/libfyaml-endian.h
@@ -44,7 +44,7 @@
 extern "C" {
 #endif
 
-#if defined(__linux__) || defined(__CYGWIN__) || defined(__OpenBSD__) || defined(__GNU__) || defined(__EMSCRIPTEN__)
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__OpenBSD__) || defined(__GNU__) || defined(__EMSCRIPTEN__) || defined(__HAIKU__)
 # include <endian.h>
 #elif defined(__APPLE__)
 # include <libkern/OSByteOrder.h>


### PR DESCRIPTION
This fixes building the latest release for appstream for us, related issue: https://github.com/ximion/appstream/issues/735