### PR TITLE
reflection: fix signed left-shift UB in 32-bit enum sign extension

### DIFF
--- a/src/reflection/fy-packed-backend.c
+++ b/src/reflection/fy-packed-backend.c
@@ -1471,7 +1471,7 @@ static int packed_reflection_setup_blob(struct fy_reflection *rfl)
 						declp->enum_value.u |= ((uint64_t)-1) << 16;
 					break;
 				case BID_U32:
-					if (declp->enum_value.u & (1 << (32 - 1)))
+					if (declp->enum_value.u & (1U << (32 - 1)))
 						declp->enum_value.u |= ((uint64_t)-1) << 32;
 					break;
 				default:


### PR DESCRIPTION
In `packed_reflection_setup_blob()` (src/reflection/fy-packed-backend.c),
the `BID_U32` sign-extension branch for `FYDT_ENUM_VALUE` tests:

```c
if (declp->enum_value.u & (1 << (32 - 1)))
```

`1` here is a plain (32-bit) `int`, so `1 << 31` overflows `INT_MAX`
(2^31 - 1) and is undefined behavior per C11 6.5.7p4. The sibling
`BID_U8` (`1 << 7`) and `BID_U16` (`1 << 15`) branches right above it
are fine, since those shift amounts stay within a signed int's range.

I confirmed this is reachable with file-controlled data: `declp->enum_value.u`
is filled from `br_rX()` / `br_r32()`, which zero-extend a 32-bit value
read directly out of the packed reflection blob into a 64-bit `uint64_t`,
so a blob with the top bit of a 32-bit enum value set will trigger the
UB shift on every affected build.

Fix: use an unsigned shift (`1U << 31`) instead, which is well-defined.
I verified with a standalone harness (the same switch-case body,
including the real `BID_U8/BID_U16/BID_U32` ordinals) compiled with
`-fsanitize=shift -fsanitize-undefined-trap-on-error`:

- Before the fix: `BID_U32` with a top-bit-set value traps (UBSan
  fires only on that branch); `BID_U8`/`BID_U16` are clean.
- After the fix: no UBSan trap for any branch, and results are
  byte-identical to the (UB) pre-fix build for both a top-bit-set
  value (correctly sign-extended to e.g. `0xffffffff80000000`) and a
  top-bit-clear value (correctly left unextended, e.g. `0x7fffffff`).

Minimal, behavior-preserving one-line change; no other branches touched.